### PR TITLE
🎨 Add Web UI and Multi-Content Support (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,23 @@ podcast-creator init
 
 ### Generate Your First Podcast
 
-#### 🚀 **New: Episode Profiles (Streamlined)**
+#### 🎨 **New: Web Interface**
+
+```bash
+# Launch the Streamlit web interface
+podcast-creator ui
+
+# Custom port/host
+podcast-creator ui --port 8080 --host 0.0.0.0
+
+# The UI provides:
+# - Visual profile management
+# - Multi-content podcast generation  
+# - Episode library with playback
+# - Import/export functionality
+```
+
+#### 🚀 **Episode Profiles (Streamlined)**
 
 ```python
 import asyncio
@@ -182,16 +198,18 @@ configure("speakers_config", {
 
 ### 🎙️ **Core Features**
 
+- **🎨 Web Interface**: Complete Streamlit UI for visual podcast creation
 - **🎯 Episode Profiles**: Pre-configured settings for one-liner podcast creation
 - **🔄 LangGraph Workflow**: Advanced state management and parallel processing
 - **👥 Multi-Speaker Support**: Dynamic 1-4 speaker configurations with rich personalities
 - **⚡ Parallel Audio Generation**: API-safe batching with concurrent processing
 - **🔧 Fully Configurable**: Multiple AI providers (OpenAI, Anthropic, Google, etc.)
-- **📊 Content Processing**: Extracts content from various sources
+- **📊 Multi-Content Support**: Combine text, files, and URLs in structured arrays
 - **🤖 AI-Powered Generation**: Creates structured outlines and natural dialogues
 - **🎵 Multi-Provider TTS**: ElevenLabs, OpenAI, Google TTS support
 - **📝 Flexible Templates**: Jinja2-based prompt customization
 - **🌍 Multilingual Support**: Generate content in multiple languages
+- **📚 Episode Library**: Built-in audio playback and transcript viewing
 
 ## 🏗️ Architecture
 
@@ -472,6 +490,15 @@ output/episode_name/
 ## 🛠️ CLI Commands
 
 ```bash
+# Launch web interface (NEW!)
+podcast-creator ui
+
+# Launch on custom port/host
+podcast-creator ui --port 8080 --host 0.0.0.0
+
+# Skip dependency check
+podcast-creator ui --skip-init-check
+
 # Initialize project with templates
 podcast-creator init
 
@@ -484,6 +511,19 @@ podcast-creator init --force
 # Show version
 podcast-creator version
 ```
+
+### 🎨 Web Interface Features
+
+The `podcast-creator ui` command launches a comprehensive Streamlit interface that provides:
+
+- **🏠 Dashboard**: Statistics and quick actions
+- **🎙️ Speaker Management**: Visual profile creation with voice selection dropdowns
+- **📺 Episode Management**: Configure generation parameters and AI models
+- **🎬 Podcast Generation**: Multi-content support (text, files, URLs) with real-time progress
+- **📚 Episode Library**: Audio playback, transcript viewing, and downloads
+- **📤 Import/Export**: Share profiles via JSON files
+
+The interface automatically detects missing dependencies and offers to run initialization if needed.
 
 ## 🚀 Performance
 
@@ -515,7 +555,7 @@ podcast-creator/
 │   └── podcast_creator/
 │       ├── __init__.py           # Public API
 │       ├── config.py             # Configuration system
-│       ├── cli.py                # CLI commands
+│       ├── cli.py                # CLI commands (with UI command)
 │       ├── core.py               # Core utilities
 │       ├── graph.py              # LangGraph workflow
 │       ├── nodes.py              # Workflow nodes
@@ -527,6 +567,7 @@ podcast-creator/
 │           ├── prompts/
 │           ├── speakers_config.json
 │           ├── episodes_config.json
+│           ├── streamlit_app/    # Web interface
 │           └── examples/
 ├── pyproject.toml               # Package configuration
 └── README.md
@@ -540,6 +581,9 @@ python -c "from podcast_creator import create_podcast; print('Import successful'
 
 # Test CLI
 podcast-creator --help
+
+# Test web interface
+podcast-creator ui
 
 # Test initialization
 mkdir test_project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "podcast-creator"
-version = "0.2.6"
+version = "0.3.0"
 license = "MIT"
 description = "AI-powered podcast generation tool that creates conversational audio content from text sources"
 readme = "README.md"
@@ -8,12 +8,17 @@ requires-python = ">=3.10.6"
 dependencies = [
     "ai-prompter>=0.3.1",
     "click>=8.0.0",
+    "content-core>=1.2.3",
     "esperanto>=2.3.2",
     "langchain-openai>=0.3.27",
     "langgraph>=0.2.74",
     "loguru>=0.7.3",
     "moviepy>=2.2.1",
+    "nest-asyncio>=1.6.0",
+    "pydub>=0.25.1",
     "python-dotenv>=1.1.1",
+    "requests>=2.32.4",
+    "streamlit>=1.46.1",
     "tiktoken>=0.9.0",
 ]
 

--- a/src/podcast_creator/cli.py
+++ b/src/podcast_creator/cli.py
@@ -3,6 +3,9 @@
 from pathlib import Path
 
 import click
+import os
+import subprocess
+import sys
 
 
 def copy_resource_file(
@@ -178,6 +181,186 @@ def version():
         click.echo(f"podcast-creator {__version__}")
     except ImportError:
         click.echo("podcast-creator (version unknown)")
+
+
+def check_dependencies_and_init() -> bool:
+    """
+    Check if required directories exist and offer to run init if not.
+    
+    Returns:
+        True if dependencies are satisfied, False otherwise
+    """
+    current_dir = Path.cwd()
+    prompts_dir = current_dir / "prompts"
+    speakers_config = current_dir / "speakers_config.json"
+    episodes_config = current_dir / "episodes_config.json"
+    
+    missing_items = []
+    
+    if not prompts_dir.exists():
+        missing_items.append("prompts directory")
+    
+    if not speakers_config.exists():
+        missing_items.append("speakers_config.json")
+        
+    if not episodes_config.exists():
+        missing_items.append("episodes_config.json")
+    
+    if not missing_items:
+        return True
+    
+    click.echo("🚨 Missing required files/directories:")
+    for item in missing_items:
+        click.echo(f"   ✗ {item}")
+    
+    click.echo(f"\nTo use the UI, you need to initialize podcast-creator in this directory.")
+    
+    if click.confirm("Would you like to run 'podcast-creator init' now?"):
+        click.echo("\n🔄 Running initialization...")
+        
+        # Run init command
+        from click.testing import CliRunner
+        runner = CliRunner()
+        result = runner.invoke(init, ['--output-dir', str(current_dir)])
+        
+        if result.exit_code == 0:
+            click.echo("✅ Initialization completed successfully!")
+            return True
+        else:
+            click.echo("❌ Initialization failed!")
+            click.echo(result.output)
+            return False
+    else:
+        click.echo("\n💡 Run 'podcast-creator init' manually to set up required files.")
+        return False
+
+
+@cli.command()
+@click.option(
+    "--port",
+    type=int,
+    default=8501,
+    help="Port to run Streamlit app on (default: 8501)",
+)
+@click.option(
+    "--host",
+    type=str,
+    default="localhost",
+    help="Host to run Streamlit app on (default: localhost)",
+)
+@click.option(
+    "--skip-init-check",
+    is_flag=True,
+    help="Skip initialization check and start UI directly",
+)
+def ui(port: int, host: str, skip_init_check: bool) -> None:
+    """
+    Launch the Streamlit web interface for Podcast Creator.
+    
+    This command starts a web-based interface that provides:
+    - Speaker and episode profile management
+    - Podcast generation with content upload
+    - Episode library and playback
+    - Profile import/export functionality
+    
+    The UI requires initialization files in the current directory.
+    Use --skip-init-check to bypass the dependency check.
+    """
+    current_dir = Path.cwd()
+    
+    # Check dependencies unless skipped
+    if not skip_init_check:
+        click.echo("🔍 Checking dependencies...")
+        if not check_dependencies_and_init():
+            click.echo("\n❌ Cannot start UI without required files.")
+            sys.exit(1)
+        
+        click.echo("✅ All dependencies satisfied!")
+    
+    # Find the streamlit app file
+    try:
+        import importlib.resources as resources
+        package_resources = resources.files("podcast_creator")
+        
+        # Check if we have a bundled streamlit app
+        app_file = None
+        try:
+            streamlit_resources = package_resources / "resources" / "streamlit_app"
+            app_resource = streamlit_resources / "app.py"
+            if app_resource.is_file():
+                # Extract to temp directory for execution
+                import tempfile
+                import shutil
+                
+                temp_dir = Path(tempfile.mkdtemp(prefix="podcast-creator-ui-"))
+                
+                # Copy the entire streamlit_app directory
+                def copy_resource_dir(source_path, target_dir):
+                    """Recursively copy resource directory."""
+                    target_dir.mkdir(parents=True, exist_ok=True)
+                    
+                    for item in source_path.iterdir():
+                        if item.is_file():
+                            try:
+                                # Try to read as text first
+                                content = item.read_text()
+                                (target_dir / item.name).write_text(content)
+                            except UnicodeDecodeError:
+                                # If it fails, read as binary
+                                content = item.read_bytes()
+                                (target_dir / item.name).write_bytes(content)
+                        elif item.is_dir():
+                            copy_resource_dir(item, target_dir / item.name)
+                
+                streamlit_dir = temp_dir / "streamlit_app"
+                copy_resource_dir(streamlit_resources, streamlit_dir)
+                app_file = streamlit_dir / "app.py"
+                
+        except Exception as e:
+            # Fall back to looking for local development copy
+            possible_paths = [
+                current_dir / "streamlit_app" / "app.py",
+                current_dir.parent / "streamlit_app" / "app.py",
+                Path(__file__).parent.parent.parent / "streamlit_app" / "app.py",
+            ]
+            
+            for path in possible_paths:
+                if path.exists():
+                    app_file = path
+                    break
+        
+        if not app_file or not app_file.exists():
+            click.echo("❌ Could not find Streamlit app file.")
+            click.echo("Please ensure the streamlit_app directory is available.")
+            sys.exit(1)
+        
+        # Start Streamlit
+        click.echo(f"🚀 Starting Podcast Creator Studio...")
+        click.echo(f"   URL: http://{host}:{port}")
+        click.echo(f"   Working directory: {current_dir}")
+        click.echo(f"   App file: {app_file}")
+        click.echo("\n   Press Ctrl+C to stop the server\n")
+        
+        # Change working directory to ensure relative paths work correctly
+        os.chdir(current_dir)
+        
+        # Run streamlit
+        cmd = [
+            sys.executable, "-m", "streamlit", "run", 
+            str(app_file),
+            "--server.port", str(port),
+            "--server.address", host,
+            "--server.headless", "true",
+            "--browser.gatherUsageStats", "false"
+        ]
+        
+        subprocess.run(cmd)
+        
+    except KeyboardInterrupt:
+        click.echo("\n👋 Shutting down Podcast Creator Studio...")
+    except Exception as e:
+        click.echo(f"❌ Error starting UI: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/podcast_creator/core.py
+++ b/src/podcast_creator/core.py
@@ -92,11 +92,7 @@ class Outline(BaseModel):
     segments: list[Segment] = Field(..., description="List of segments")
 
     def model_dump(self, **kwargs) -> Dict[str, Any]:
-        return {
-            "segments": [
-                segment.model_dump(**kwargs) for segment in self.segments
-            ]
-        }
+        return {"segments": [segment.model_dump(**kwargs) for segment in self.segments]}
 
 
 class Dialogue(BaseModel):
@@ -213,7 +209,7 @@ async def combine_audio_files(
     list_of_audio_paths = sorted(audio_dir.glob("*.mp3"))
     output_filename_from_input = final_filename
 
-    logger.warning(list_of_audio_paths)
+    logger.debug(list_of_audio_paths)
 
     if not list_of_audio_paths:
         logger.warning(

--- a/src/podcast_creator/graph.py
+++ b/src/podcast_creator/graph.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, List, Union
 
 from langgraph.graph import END, START, StateGraph
 from loguru import logger
@@ -40,7 +40,7 @@ graph = workflow.compile()
 
 
 async def create_podcast(
-    content: str,
+    content: Union[str, List[Dict]],
     briefing: Optional[str] = None,
     episode_name: Optional[str] = None,
     output_dir: Optional[str] = None,

--- a/src/podcast_creator/resources/prompts/podcast/outline.jinja
+++ b/src/podcast_creator/resources/prompts/podcast/outline.jinja
@@ -5,9 +5,14 @@ Here is the briefing for the podcast episode:
 {{ briefing }}
 </briefing>
 
-The user has attached a document to be used as the context for this podcast episode:
+The user has provided content to be used as the context for this podcast episode:
 <context>
-{{ context }}
+{% for item in context %}
+<item>
+<title>{{ item.title }}</title>
+<content>{{ item.content }}</content>
+</item>
+{% endfor %}
 </context>
 
 The podcast will feature the following speakers:

--- a/src/podcast_creator/resources/prompts/podcast/transcript.jinja
+++ b/src/podcast_creator/resources/prompts/podcast/transcript.jinja
@@ -7,9 +7,14 @@ First, review the briefing for the podcast episode:
 {{ briefing }}
 </briefing>
 
-The user has attached a document to be used as the context for this podcast episode:
+The user has provided content to be used as the context for this podcast episode:
 <context>
-{{ context }}
+{% for item in context %}
+<item>
+<title>{{ item.title }}</title>
+<content>{{ item.content }}</content>
+</item>
+{% endfor %}
 </context>
 
 The podcast features the following speakers:

--- a/src/podcast_creator/resources/streamlit_app/README.md
+++ b/src/podcast_creator/resources/streamlit_app/README.md
@@ -1,0 +1,227 @@
+# Podcast Creator Studio - Streamlit Interface
+
+A comprehensive web interface for the podcast-creator library that enables users to manage speaker profiles, episode profiles, and generate AI-powered podcasts. 
+
+🚀 **Launch directly with**: `podcast-creator ui`
+
+## Features
+
+### 🏠 Home Dashboard
+- Quick stats (episodes, profiles)
+- Recent episodes overview
+- Quick access to main functions
+
+### 🎙️ Speaker Profiles Management
+- Create, edit, clone, and delete speaker profiles
+- Import/export profiles from/to JSON files
+- Support for multiple TTS providers (ElevenLabs, OpenAI, Google)
+- Manage up to 4 speakers per profile
+
+### 📺 Episode Profiles Management
+- Create, edit, clone, and delete episode configurations
+- Link episode profiles to speaker profiles
+- Configure AI models, segments, and default briefings
+- Grid-based profile overview
+
+### 🎬 Podcast Generation
+- Generate podcasts using episode and speaker profiles
+- **Multi-content support**: Combine multiple sources in structured arrays
+- Support for multiple content sources:
+  - Direct text input
+  - File upload (TXT, PDF, DOCX, MD, JSON)
+  - URL content extraction (with content-core)
+- **Voice selection dropdowns**: Provider-specific voice options
+- **Provider availability checking**: Shows only available AI providers
+- Real-time generation progress tracking
+- Episode name conflict detection with overwrite confirmation
+- Comprehensive error handling with retry options
+
+### 📚 Episode Library
+- Browse generated episodes with search and filtering
+- Audio playback with built-in player
+- View transcripts and outlines
+- Download episodes as MP3 files
+- Delete episodes with confirmation
+- Grid and list view modes
+- Library statistics
+
+## Quick Start
+
+### 🚀 **Recommended: Use CLI Command**
+
+```bash
+# Install podcast-creator
+pip install podcast-creator
+
+# Launch the web interface (handles all setup automatically)
+podcast-creator ui
+
+# Custom port/host
+podcast-creator ui --port 8080 --host 0.0.0.0
+```
+
+The CLI command automatically:
+- Checks for required dependencies
+- Offers to run initialization if needed  
+- Extracts and runs the bundled Streamlit app
+- Uses your current directory for all configs
+
+### 📁 **Manual Installation (Development)**
+
+1. **Install dependencies:**
+   ```bash
+   uv add streamlit pydub requests content-core
+   ```
+
+2. **Run manually:**
+   ```bash
+   streamlit run app.py
+   ```
+
+3. **Open your browser to:**
+   ```
+   http://localhost:8501
+   ```
+
+## Configuration
+
+### 🎯 **Automatic Configuration (CLI)**
+
+When using `podcast-creator ui`, the app:
+- Uses your current working directory for all configs
+- Automatically creates missing files via `podcast-creator init`
+- Supports all podcast-creator configuration options
+
+### 📁 **File Structure**
+
+The app uses these files in your working directory:
+- `speakers_config.json`: Speaker profile configurations
+- `episodes_config.json`: Episode profile configurations  
+- `prompts/`: Jinja2 template directory
+- `output/`: Generated podcasts directory
+
+## Profile Structure
+
+### Speaker Profile Format
+```json
+{
+  "profiles": {
+    "profile_name": {
+      "tts_provider": "elevenlabs",
+      "tts_model": "eleven_flash_v2_5",
+      "speakers": [
+        {
+          "name": "Speaker Name",
+          "voice_id": "voice_id_from_provider",
+          "backstory": "Rich background that informs expertise",
+          "personality": "Speaking style and traits"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Episode Profile Format
+```json
+{
+  "profiles": {
+    "profile_name": {
+      "speaker_config": "speaker_profile_name",
+      "outline_model": "gpt-4o",
+      "transcript_model": "gpt-4o",
+      "num_segments": 4,
+      "default_briefing": "Instructions for podcast generation"
+    }
+  }
+}
+```
+
+## Error Handling
+
+The application includes comprehensive error handling:
+
+- **API Errors**: Timeout, rate limiting, authentication issues
+- **Content Errors**: Invalid or missing content
+- **File Errors**: Missing files, permission issues
+- **Generation Errors**: Podcast creation failures
+
+All errors display user-friendly messages with suggested solutions and retry options.
+
+## Features Overview
+
+### Content Extraction
+- **Multi-Content Support**: Combine multiple sources in structured arrays
+- **Text Input**: Direct paste of content
+- **File Upload**: Supports common document formats (TXT, PDF, DOCX, MD, JSON)
+- **URL Extraction**: Fetch content from web pages (requires content-core)
+- **Content Management**: Add, remove, and reorder content pieces
+
+### Profile Management
+- **CRUD Operations**: Full create, read, update, delete functionality
+- **Voice Selection**: Provider-specific dropdown menus
+- **Provider Checking**: Shows only available AI providers based on API keys
+- **Import/Export**: JSON-based profile sharing
+- **Validation**: Comprehensive profile validation
+- **Cloning**: Duplicate profiles for quick customization
+
+### Podcast Generation
+- **Episode Profiles**: Use pre-configured settings
+- **Multi-Content Generation**: Pass structured content arrays to AI prompts
+- **Provider Availability**: Dynamic provider selection based on environment
+- **Override Options**: Customize generation parameters
+- **Progress Tracking**: Real-time generation status
+- **Error Recovery**: Retry failed generations
+
+### Episode Library
+- **Audio Playback**: Built-in Streamlit audio player
+- **Transcript Viewing**: Formatted dialogue display with speaker names
+- **Download**: Save episodes as MP3 files
+- **Search & Filter**: Find episodes quickly
+- **Statistics**: Library overview metrics
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"content-core library not available"**
+   - Install with: `uv add content-core`
+   - Or use direct text input instead
+
+2. **"podcast-creator library not available"**
+   - Make sure you're in the correct project directory
+   - The main podcast-creator package should be installed
+
+3. **Audio files not playing**
+   - Check that episodes were generated successfully
+   - Verify the output directory contains audio files
+
+4. **Profile import failures**
+   - Ensure JSON format is correct
+   - Check that required fields are present
+
+### Getting Help
+
+- Check the error messages for specific guidance
+- Use the retry functionality for temporary issues
+- Verify your API keys and configuration
+- Ensure all required dependencies are installed
+
+## Development
+
+The application is structured as follows:
+
+```
+streamlit_app/
+├── app.py                 # Main application
+├── utils/                 # Utility modules
+│   ├── episode_manager.py # Episode management
+│   ├── profile_manager.py # Profile CRUD operations
+│   ├── content_extractor.py # Content processing
+│   ├── async_helpers.py   # Async utilities
+│   └── error_handler.py   # Error handling
+├── requirements.txt       # Dependencies
+└── README.md             # This file
+```
+
+The app follows Streamlit best practices with modular utilities and comprehensive error handling.

--- a/src/podcast_creator/resources/streamlit_app/app.py
+++ b/src/podcast_creator/resources/streamlit_app/app.py
@@ -1,0 +1,1840 @@
+"""
+Podcast Creator Studio - Streamlit Interface
+
+A comprehensive web interface for managing speaker profiles, episode profiles,
+and generating podcasts using the podcast-creator library.
+"""
+
+import nest_asyncio
+nest_asyncio.apply()
+
+import streamlit as st
+import os
+import sys
+import json
+from pathlib import Path
+
+# Add the parent directory to the path to import podcast_creator
+sys.path.append(str(Path(__file__).parent.parent))
+
+# Import utilities
+from utils import EpisodeManager, ProfileManager, ContentExtractor, run_async_in_streamlit, ErrorHandler, VoiceProvider, ProviderChecker
+
+# Use current working directory for all profile management
+WORKING_DIR = Path.cwd()
+
+# Configure page
+st.set_page_config(
+    page_title="Podcast Creator Studio",
+    page_icon="🎙️",
+    layout="wide",
+    initial_sidebar_state="expanded"
+)
+
+# Custom CSS for better styling
+st.markdown("""
+<style>
+    .main-header {
+        font-size: 2.5rem;
+        font-weight: bold;
+        color: #1f1f1f;
+        text-align: center;
+        margin-bottom: 2rem;
+    }
+    
+    .stat-card {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        padding: 1rem;
+        border-radius: 10px;
+        margin: 0.5rem;
+        text-align: center;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    }
+    
+    .stat-number {
+        font-size: 2rem;
+        font-weight: bold;
+        margin: 0;
+    }
+    
+    .stat-label {
+        font-size: 0.9rem;
+        margin: 0;
+        opacity: 0.9;
+    }
+    
+    .quick-action-card {
+        background: #f8f9fa;
+        padding: 1.5rem;
+        border-radius: 10px;
+        border: 1px solid #e9ecef;
+        margin: 0.5rem;
+        text-align: center;
+        transition: all 0.3s ease;
+    }
+    
+    .quick-action-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    }
+    
+    .sidebar .sidebar-content {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    }
+</style>
+""", unsafe_allow_html=True)
+
+def main():
+    """Main application entry point."""
+    
+    # Header
+    st.markdown('<div class="main-header">🎙️ Podcast Creator Studio</div>', unsafe_allow_html=True)
+    
+    # Initialize current page in session state
+    if 'current_page' not in st.session_state:
+        st.session_state.current_page = "🏠 Home"
+    
+    # Handle programmatic navigation
+    if st.session_state.get('navigate_to_library', False):
+        st.session_state.current_page = "📚 Episode Library"
+        st.session_state.navigate_to_library = False
+    
+    # Sidebar navigation
+    with st.sidebar:
+        st.title("Navigation")
+        st.markdown("---")
+        
+        # Navigation menu
+        pages = [
+            "🏠 Home",
+            "🎙️ Speaker Profiles", 
+            "📺 Episode Profiles",
+            "🎬 Generate Podcast",
+            "📚 Episode Library"
+        ]
+        
+        # Find current page index
+        current_index = pages.index(st.session_state.current_page) if st.session_state.current_page in pages else 0
+        
+        page = st.selectbox(
+            "Choose a page:",
+            pages,
+            index=current_index,
+            key="navigation_selectbox"
+        )
+        
+        # Update current page if changed
+        if page != st.session_state.current_page:
+            st.session_state.current_page = page
+            st.rerun()
+        
+        st.markdown("---")
+        st.markdown("### Quick Actions")
+        
+        if st.button("🎬 Generate Podcast", use_container_width=True):
+            st.session_state.current_page = "🎬 Generate Podcast"
+            st.rerun()
+            
+        if st.button("📚 View Episodes", use_container_width=True):
+            st.session_state.current_page = "📚 Episode Library"
+            st.rerun()
+    
+    # Use the current page from session state
+    page = st.session_state.current_page
+    
+    # Route to appropriate page
+    if page == "🏠 Home":
+        show_home_page()
+    elif page == "🎙️ Speaker Profiles":
+        show_speaker_profiles_page()
+    elif page == "📺 Episode Profiles":
+        show_episode_profiles_page()
+    elif page == "🎬 Generate Podcast":
+        show_generate_podcast_page()
+    elif page == "📚 Episode Library":
+        show_episode_library_page()
+
+def show_home_page():
+    """Display the home page with dashboard and quick stats."""
+    st.subheader("Welcome to Podcast Creator Studio")
+    st.markdown("Your all-in-one solution for AI-powered podcast creation")
+    
+    # Initialize managers
+    episode_manager = EpisodeManager(base_output_dir=WORKING_DIR / "output")
+    profile_manager = ProfileManager(working_dir=WORKING_DIR)
+    
+    # Get stats
+    try:
+        episodes_stats = episode_manager.get_episodes_stats()
+        profiles_stats = profile_manager.get_profiles_stats()
+        
+        # Quick stats
+        col1, col2, col3 = st.columns(3)
+        
+        with col1:
+            st.markdown(f"""
+            <div class="stat-card">
+                <p class="stat-number">{episodes_stats['total_episodes']}</p>
+                <p class="stat-label">Total Episodes</p>
+            </div>
+            """, unsafe_allow_html=True)
+        
+        with col2:
+            st.markdown(f"""
+            <div class="stat-card">
+                <p class="stat-number">{profiles_stats['speaker_profiles_count']}</p>
+                <p class="stat-label">Speaker Profiles</p>
+            </div>
+            """, unsafe_allow_html=True)
+        
+        with col3:
+            st.markdown(f"""
+            <div class="stat-card">
+                <p class="stat-number">{profiles_stats['episode_profiles_count']}</p>
+                <p class="stat-label">Episode Profiles</p>
+            </div>
+            """, unsafe_allow_html=True)
+        
+        st.markdown("---")
+        
+        # Recent episodes
+        st.subheader("Recent Episodes")
+        
+        recent_episodes = episode_manager.scan_episodes_directory()
+        if recent_episodes:
+            for episode in recent_episodes[:5]:  # Show last 5 episodes
+                col1, col2, col3 = st.columns([3, 1, 1])
+                
+                with col1:
+                    st.markdown(f"**{episode.name}**")
+                    if episode.created_date:
+                        st.markdown(f"*Created: {episode.created_date.strftime('%Y-%m-%d %H:%M')}*")
+                    if episode.duration:
+                        st.markdown(f"*Duration: {episode_manager.format_duration(episode.duration)}*")
+                
+                with col2:
+                    if episode.audio_file and st.button("▶️ Play", key=f"play_{episode.name}"):
+                        st.session_state.selected_episode = episode
+                        st.session_state.current_page = "📚 Episode Library"
+                        st.rerun()
+                
+                with col3:
+                    if st.button("📄 Details", key=f"details_{episode.name}"):
+                        st.session_state.selected_episode = episode
+                        st.session_state.current_page = "📚 Episode Library"
+                        st.rerun()
+                
+                st.markdown("---")
+        else:
+            st.info("📝 No episodes found. Start by generating your first podcast!")
+        
+        st.markdown("---")
+        
+        # Provider Status
+        st.markdown("---")
+        ProviderChecker.show_provider_status()
+        
+        st.markdown("---")
+        
+        # Quick actions
+        st.subheader("Quick Actions")
+        
+        col1, col2 = st.columns(2)
+        
+        with col1:
+            if st.button("🎬 Create New Podcast", use_container_width=True, type="primary"):
+                st.session_state.current_page = "🎬 Generate Podcast"
+                st.rerun()
+        
+        with col2:
+            if st.button("📁 Import Profiles", use_container_width=True):
+                st.session_state.current_page = "🎙️ Speaker Profiles"
+                st.rerun()
+    
+    except Exception as e:
+        st.error(f"Error loading home page data: {str(e)}")
+        st.markdown("Please check that all required files are in place and try again.")
+
+def show_speaker_profiles_page():
+    """Display the speaker profiles management page."""
+    st.subheader("🎙️ Speaker Profiles")
+    st.markdown("Manage your speaker configurations")
+    
+    # Initialize profile manager
+    profile_manager = ProfileManager(working_dir=WORKING_DIR)
+    
+    # Load profiles
+    try:
+        profiles = profile_manager.load_speaker_profiles()
+        profile_names = list(profiles.get("profiles", {}).keys())
+        
+        # Action buttons
+        col1, col2, col3 = st.columns(3)
+        
+        with col1:
+            if st.button("➕ New Profile", use_container_width=True):
+                st.session_state.show_new_speaker_form = True
+                st.rerun()
+        
+        with col2:
+            if st.button("📁 Import", use_container_width=True):
+                st.session_state.show_import_speaker_form = True
+                st.rerun()
+        
+        with col3:
+            if st.button("💾 Export All", use_container_width=True):
+                export_data = profile_manager.export_speaker_profiles()
+                st.download_button(
+                    label="Download speakers_config.json",
+                    data=json.dumps(export_data, indent=2),
+                    file_name="speakers_config.json",
+                    mime="application/json"
+                )
+        
+        st.markdown("---")
+        
+        # Import form
+        if st.session_state.get("show_import_speaker_form", False):
+            st.subheader("📁 Import Speaker Profiles")
+            
+            uploaded_file = st.file_uploader(
+                "Choose a JSON file to import",
+                type=['json'],
+                key="speaker_import_file"
+            )
+            
+            if uploaded_file is not None:
+                try:
+                    file_content = uploaded_file.read().decode('utf-8')
+                    imported_names = profile_manager.import_speaker_profiles(file_content)
+                    
+                    if imported_names:
+                        st.success(f"✅ Successfully imported {len(imported_names)} profiles: {', '.join(imported_names)}")
+                        st.session_state.show_import_speaker_form = False
+                        st.rerun()
+                    else:
+                        st.warning("⚠️ No new profiles imported. Check if profiles already exist or file format is correct.")
+                except Exception as e:
+                    st.error(f"❌ Error importing profiles: {str(e)}")
+            
+            if st.button("❌ Cancel Import"):
+                st.session_state.show_import_speaker_form = False
+                st.rerun()
+            
+            st.markdown("---")
+        
+        # New profile form
+        if st.session_state.get("show_new_speaker_form", False):
+            st.subheader("➕ Create New Speaker Profile")
+            
+            profile_name = st.text_input("Profile Name:", placeholder="e.g., my_podcasters", key="new_profile_name")
+            
+            col1, col2 = st.columns(2)
+            with col1:
+                tts_provider = ProviderChecker.render_tts_provider_selector(
+                    "TTS Provider:",
+                    current_provider="elevenlabs",
+                    key="new_tts_provider",
+                    help_text="Choose a Text-to-Speech provider"
+                )
+            with col2:
+                # Get default model for selected provider
+                defaults = ProviderChecker.get_default_models(tts_provider)
+                default_model = defaults.get("tts", "eleven_flash_v2_5")
+                tts_model = st.text_input("TTS Model:", value=default_model, key="new_tts_model")
+            
+            st.markdown("### Speakers")
+            
+            # Initialize speakers in session state
+            if 'new_speakers' not in st.session_state:
+                st.session_state.new_speakers = [{'name': '', 'voice_id': '', 'backstory': '', 'personality': ''}]
+            
+            for i, speaker in enumerate(st.session_state.new_speakers):
+                st.markdown(f"**Speaker {i+1}:**")
+                col1, col2 = st.columns([4, 1])
+                
+                with col1:
+                    speaker_name = st.text_input(f"Name:", key=f"new_speaker_name_{i}", value=speaker.get('name', ''))
+                    
+                    # Voice selection with provider-specific voices
+                    voice_id = VoiceProvider.render_voice_selector(
+                        provider=tts_provider,
+                        model=tts_model,
+                        current_voice_id=speaker.get('voice_id', ''),
+                        key=f"new_voice_id_{i}",
+                        help_text=f"Choose a voice from {tts_provider}"
+                    )
+                    
+                    # Show voice preview if available
+                    if voice_id and tts_provider == "elevenlabs":
+                        with st.expander("🎵 Voice Preview"):
+                            VoiceProvider.render_voice_preview(tts_provider, voice_id)
+                    
+                    backstory = st.text_area(f"Backstory:", key=f"new_backstory_{i}", value=speaker.get('backstory', ''))
+                    personality = st.text_area(f"Personality:", key=f"new_personality_{i}", value=speaker.get('personality', ''))
+                    
+                    # Update speaker data
+                    st.session_state.new_speakers[i] = {
+                        'name': speaker_name,
+                        'voice_id': voice_id,
+                        'backstory': backstory,
+                        'personality': personality
+                    }
+                
+                with col2:
+                    if len(st.session_state.new_speakers) > 1:
+                        if st.button(f"🗑️", key=f"new_remove_speaker_{i}"):
+                            st.session_state.new_speakers.pop(i)
+                            st.rerun()
+                
+                st.markdown("---")
+            
+            col1, col2 = st.columns(2)
+            with col1:
+                if st.button("➕ Add Speaker", key="new_add_speaker") and len(st.session_state.new_speakers) < 4:
+                    st.session_state.new_speakers.append({'name': '', 'voice_id': '', 'backstory': '', 'personality': ''})
+                    st.rerun()
+            
+            st.markdown("---")
+            
+            # Action buttons
+            col1, col2 = st.columns(2)
+            
+            with col1:
+                if st.button("✅ Create Profile", type="primary", key="create_speaker_profile"):
+                    if not profile_name:
+                        st.error("Profile name is required")
+                    elif profile_name in profile_names:
+                        st.error(f"Profile '{profile_name}' already exists")
+                    else:
+                        # Create profile data
+                        profile_data = {
+                            "tts_provider": tts_provider,
+                            "tts_model": tts_model,
+                            "speakers": st.session_state.new_speakers
+                        }
+                        
+                        # Validate profile
+                        validation_errors = profile_manager.validate_speaker_profile(profile_data)
+                        if validation_errors:
+                            st.error("❌ Validation errors:")
+                            for error in validation_errors:
+                                st.error(f"• {error}")
+                        else:
+                            # Create the profile
+                            if profile_manager.create_speaker_profile(profile_name, profile_data):
+                                st.success(f"✅ Profile '{profile_name}' created successfully!")
+                                st.session_state.show_new_speaker_form = False
+                                if 'new_speakers' in st.session_state:
+                                    del st.session_state.new_speakers
+                                st.rerun()
+                            else:
+                                st.error("❌ Failed to create profile")
+            
+            with col2:
+                if st.button("❌ Cancel", key="cancel_new_speaker"):
+                    st.session_state.show_new_speaker_form = False
+                    if 'new_speakers' in st.session_state:
+                        del st.session_state.new_speakers
+                    st.rerun()
+            
+            st.markdown("---")
+        
+        # Edit profile form
+        if st.session_state.get("edit_speaker_profile"):
+            edit_profile_name = st.session_state.edit_speaker_profile
+            edit_profile_data = profile_manager.get_speaker_profile(edit_profile_name)
+            
+            if edit_profile_data:
+                st.subheader(f"✏️ Edit Speaker Profile: {edit_profile_name}")
+                
+                col1, col2 = st.columns(2)
+                with col1:
+                    current_tts_provider = edit_profile_data.get('tts_provider', 'elevenlabs')
+                    tts_provider = ProviderChecker.render_tts_provider_selector(
+                        "TTS Provider:",
+                        current_provider=current_tts_provider,
+                        key="edit_speaker_tts_provider",
+                        help_text="Choose a Text-to-Speech provider"
+                    )
+                with col2:
+                    # Get default model for selected provider
+                    defaults = ProviderChecker.get_default_models(tts_provider)
+                    default_model = defaults.get("tts", "eleven_flash_v2_5")
+                    
+                    current_tts_model = edit_profile_data.get('tts_model', default_model)
+                    tts_model = st.text_input(
+                        "TTS Model:", 
+                        value=current_tts_model,
+                        key="edit_speaker_tts_model"
+                    )
+                
+                st.markdown("### Speakers")
+                
+                # Initialize edit speakers
+                if 'edit_speakers' not in st.session_state:
+                    st.session_state.edit_speakers = edit_profile_data.get('speakers', [])
+                
+                for i, speaker in enumerate(st.session_state.edit_speakers):
+                    st.markdown(f"**Speaker {i+1}:**")
+                    col1, col2 = st.columns([4, 1])
+                    
+                    with col1:
+                        speaker_name = st.text_input(
+                            f"Name:", 
+                            key=f"edit_speaker_name_{i}", 
+                            value=speaker.get('name', '')
+                        )
+                        
+                        # Voice selection with provider-specific voices
+                        voice_id = VoiceProvider.render_voice_selector(
+                            provider=tts_provider,
+                            model=tts_model,
+                            current_voice_id=speaker.get('voice_id', ''),
+                            key=f"edit_voice_id_{i}",
+                            help_text=f"Choose a voice from {tts_provider}"
+                        )
+                        
+                        # Show voice preview if available
+                        if voice_id and tts_provider == "elevenlabs":
+                            with st.expander("🎵 Voice Preview"):
+                                VoiceProvider.render_voice_preview(tts_provider, voice_id)
+                        
+                        backstory = st.text_area(
+                            f"Backstory:", 
+                            key=f"edit_backstory_{i}", 
+                            value=speaker.get('backstory', '')
+                        )
+                        personality = st.text_area(
+                            f"Personality:", 
+                            key=f"edit_personality_{i}", 
+                            value=speaker.get('personality', '')
+                        )
+                        
+                        # Update speaker data
+                        st.session_state.edit_speakers[i] = {
+                            'name': speaker_name,
+                            'voice_id': voice_id,
+                            'backstory': backstory,
+                            'personality': personality
+                        }
+                    
+                    with col2:
+                        if len(st.session_state.edit_speakers) > 1:
+                            if st.button(f"🗑️", key=f"edit_remove_speaker_{i}"):
+                                st.session_state.edit_speakers.pop(i)
+                                st.rerun()
+                    
+                    st.markdown("---")
+                
+                col1, col2 = st.columns(2)
+                with col1:
+                    if st.button("➕ Add Speaker", key="edit_add_speaker") and len(st.session_state.edit_speakers) < 4:
+                        st.session_state.edit_speakers.append({'name': '', 'voice_id': '', 'backstory': '', 'personality': ''})
+                        st.rerun()
+                
+                st.markdown("---")
+                
+                # Action buttons
+                col1, col2 = st.columns(2)
+                
+                with col1:
+                    if st.button("✅ Save Changes", type="primary", key="save_speaker_changes"):
+                        # Update profile data
+                        updated_profile_data = {
+                            "tts_provider": tts_provider,
+                            "tts_model": tts_model,
+                            "speakers": st.session_state.edit_speakers
+                        }
+                        
+                        # Validate profile
+                        validation_errors = profile_manager.validate_speaker_profile(updated_profile_data)
+                        if validation_errors:
+                            st.error("❌ Validation errors:")
+                            for error in validation_errors:
+                                st.error(f"• {error}")
+                        else:
+                            # Update the profile
+                            if profile_manager.update_speaker_profile(edit_profile_name, updated_profile_data):
+                                st.success(f"✅ Profile '{edit_profile_name}' updated successfully!")
+                                st.session_state.edit_speaker_profile = None
+                                if 'edit_speakers' in st.session_state:
+                                    del st.session_state.edit_speakers
+                                st.rerun()
+                            else:
+                                st.error("❌ Failed to update profile")
+                
+                with col2:
+                    if st.button("❌ Cancel Edit", key="cancel_edit_speaker"):
+                        st.session_state.edit_speaker_profile = None
+                        if 'edit_speakers' in st.session_state:
+                            del st.session_state.edit_speakers
+                        st.rerun()
+                
+                st.markdown("---")
+            else:
+                st.error(f"Speaker profile '{edit_profile_name}' not found")
+                st.session_state.edit_speaker_profile = None
+                st.rerun()
+        
+        # Display existing profiles
+        st.subheader("Existing Speaker Profiles")
+        
+        if profile_names:
+            for profile_name in profile_names:
+                profile_data = profiles["profiles"][profile_name]
+                
+                with st.expander(f"🎙️ {profile_name}", expanded=False):
+                    col1, col2 = st.columns([3, 1])
+                    
+                    with col1:
+                        st.markdown(f"**TTS Provider:** {profile_data.get('tts_provider', 'N/A')}")
+                        st.markdown(f"**TTS Model:** {profile_data.get('tts_model', 'N/A')}")
+                        st.markdown(f"**Number of Speakers:** {len(profile_data.get('speakers', []))}")
+                        
+                        # Show speakers
+                        speakers = profile_data.get('speakers', [])
+                        if speakers:
+                            st.markdown("**Speakers:**")
+                            for i, speaker in enumerate(speakers):
+                                st.markdown(f"• **{speaker.get('name', 'Unnamed')}** - {speaker.get('voice_id', 'No voice ID')}")
+                    
+                    with col2:
+                        st.markdown("**Actions:**")
+                        
+                        # Edit button
+                        if st.button("✏️ Edit", key=f"edit_{profile_name}"):
+                            st.session_state.edit_speaker_profile = profile_name
+                            st.rerun()
+                        
+                        # Clone button
+                        if st.button("📋 Clone", key=f"clone_{profile_name}"):
+                            new_name = f"{profile_name}_copy"
+                            if profile_manager.clone_speaker_profile(profile_name, new_name):
+                                st.success(f"✅ Profile cloned as '{new_name}'")
+                                st.rerun()
+                            else:
+                                st.error("❌ Failed to clone profile")
+                        
+                        # Export button
+                        export_data = profile_manager.export_speaker_profiles([profile_name])
+                        st.download_button(
+                            label="💾 Export",
+                            data=json.dumps(export_data, indent=2),
+                            file_name=f"{profile_name}_speaker_config.json",
+                            mime="application/json",
+                            key=f"export_{profile_name}"
+                        )
+                        
+                        # Delete button
+                        if st.button("🗑️ Delete", key=f"delete_{profile_name}"):
+                            if profile_manager.delete_speaker_profile(profile_name):
+                                st.success(f"✅ Profile '{profile_name}' deleted")
+                                st.rerun()
+                            else:
+                                st.error("❌ Failed to delete profile")
+        else:
+            st.info("No speaker profiles found. Create your first profile to get started!")
+    
+    except Exception as e:
+        st.error(f"Error loading speaker profiles: {str(e)}")
+        st.markdown("Please check your configuration files and try again.")
+
+def show_episode_profiles_page():
+    """Display the episode profiles management page."""
+    st.subheader("📺 Episode Profiles")
+    st.markdown("Manage your episode configurations")
+    
+    # Define available providers for use throughout the function
+    all_providers = ["openai", "anthropic", "google", "groq", "ollama", "openrouter", "azure", "mistral", "deepseek", "xai"]
+    
+    # Initialize profile manager
+    profile_manager = ProfileManager(working_dir=WORKING_DIR)
+    
+    # Load profiles
+    try:
+        profiles = profile_manager.load_episode_profiles()
+        profile_names = list(profiles.get("profiles", {}).keys())
+        speaker_profile_names = profile_manager.get_speaker_profile_names()
+        
+        # Action buttons
+        col1, col2, col3 = st.columns(3)
+        
+        with col1:
+            if st.button("➕ New Profile", use_container_width=True):
+                st.session_state.show_new_episode_form = True
+                st.rerun()
+        
+        with col2:
+            if st.button("📁 Import", use_container_width=True):
+                st.session_state.show_import_episode_form = True
+                st.rerun()
+        
+        with col3:
+            if st.button("💾 Export All", use_container_width=True):
+                export_data = profile_manager.export_episode_profiles()
+                st.download_button(
+                    label="Download episodes_config.json",
+                    data=json.dumps(export_data, indent=2),
+                    file_name="episodes_config.json",
+                    mime="application/json"
+                )
+        
+        st.markdown("---")
+        
+        # Import form
+        if st.session_state.get("show_import_episode_form", False):
+            st.subheader("📁 Import Episode Profiles")
+            
+            uploaded_file = st.file_uploader(
+                "Choose a JSON file to import",
+                type=['json'],
+                key="episode_import_file"
+            )
+            
+            if uploaded_file is not None:
+                try:
+                    file_content = uploaded_file.read().decode('utf-8')
+                    imported_names = profile_manager.import_episode_profiles(file_content)
+                    
+                    if imported_names:
+                        st.success(f"✅ Successfully imported {len(imported_names)} profiles: {', '.join(imported_names)}")
+                        st.session_state.show_import_episode_form = False
+                        st.rerun()
+                    else:
+                        st.warning("⚠️ No new profiles imported. Check if profiles already exist or file format is correct.")
+                except Exception as e:
+                    st.error(f"❌ Error importing profiles: {str(e)}")
+            
+            if st.button("❌ Cancel Import"):
+                st.session_state.show_import_episode_form = False
+                st.rerun()
+            
+            st.markdown("---")
+        
+        # New profile form
+        if st.session_state.get("show_new_episode_form", False):
+            st.subheader("➕ Create New Episode Profile")
+            
+            profile_name = st.text_input("Profile Name:", placeholder="e.g., my_tech_talks", key="new_episode_name")
+            
+            if speaker_profile_names:
+                speaker_config = st.selectbox("Speaker Profile:", speaker_profile_names, key="new_episode_speaker")
+            else:
+                st.error("⚠️ No speaker profiles found. Please create a speaker profile first.")
+                speaker_config = None
+            
+            st.markdown("### AI Model Configuration")
+            
+            # Outline Model Configuration
+            st.markdown("**Outline Generation:**")
+            col1, col2 = st.columns(2)
+            with col1:
+                outline_provider = ProviderChecker.render_provider_selector(
+                    "Outline Provider:",
+                    all_providers,
+                    current_provider="openai",
+                    key="new_episode_outline_provider",
+                    help_text="Choose an AI provider for generating podcast outlines"
+                )
+            with col2:
+                # Get default model for selected provider
+                defaults = ProviderChecker.get_default_models(outline_provider)
+                default_outline_model = defaults.get("outline", "gpt-4o")
+                
+                outline_model = st.text_input(
+                    "Outline Model:",
+                    value=default_outline_model,
+                    placeholder=default_outline_model,
+                    key="new_episode_outline_model"
+                )
+            
+            # Transcript Model Configuration
+            st.markdown("**Transcript Generation:**")
+            col1, col2 = st.columns(2)
+            with col1:
+                transcript_provider = ProviderChecker.render_provider_selector(
+                    "Transcript Provider:",
+                    all_providers,
+                    current_provider="openai",
+                    key="new_episode_transcript_provider",
+                    help_text="Choose an AI provider for generating podcast transcripts"
+                )
+            with col2:
+                # Get default model for selected provider
+                defaults = ProviderChecker.get_default_models(transcript_provider)
+                default_transcript_model = defaults.get("transcript", "gpt-4o")
+                
+                transcript_model = st.text_input(
+                    "Transcript Model:",
+                    value=default_transcript_model,
+                    placeholder=default_transcript_model,
+                    key="new_episode_transcript_model"
+                )
+            
+            num_segments = st.slider("Number of Segments:", 1, 10, 4, key="new_episode_segments")
+            default_briefing = st.text_area(
+                "Default Briefing:", 
+                value="Create an engaging discussion about the topic",
+                height=100,
+                key="new_episode_briefing"
+            )
+            
+            st.markdown("---")
+            
+            # Action buttons
+            col1, col2 = st.columns(2)
+            
+            with col1:
+                if st.button("✅ Create Profile", type="primary", key="create_episode_profile"):
+                    if not profile_name:
+                        st.error("Profile name is required")
+                    elif profile_name in profile_names:
+                        st.error(f"Profile '{profile_name}' already exists")
+                    elif not speaker_config:
+                        st.error("Speaker profile is required")
+                    else:
+                        # Create profile data with provider information
+                        profile_data = {
+                            "speaker_config": speaker_config,
+                            "outline_model": outline_model,
+                            "outline_provider": outline_provider,
+                            "transcript_model": transcript_model,
+                            "transcript_provider": transcript_provider,
+                            "num_segments": num_segments,
+                            "default_briefing": default_briefing
+                        }
+                        
+                        # Validate profile
+                        validation_errors = profile_manager.validate_episode_profile(profile_data)
+                        if validation_errors:
+                            st.error("❌ Validation errors:")
+                            for error in validation_errors:
+                                st.error(f"• {error}")
+                        else:
+                            # Create the profile
+                            if profile_manager.create_episode_profile(profile_name, profile_data):
+                                st.success(f"✅ Profile '{profile_name}' created successfully!")
+                                st.session_state.show_new_episode_form = False
+                                st.rerun()
+                            else:
+                                st.error("❌ Failed to create profile")
+            
+            with col2:
+                if st.button("❌ Cancel", key="cancel_new_episode"):
+                    st.session_state.show_new_episode_form = False
+                    st.rerun()
+            
+            st.markdown("---")
+        
+        # Edit profile form
+        if st.session_state.get("edit_episode_profile"):
+            edit_profile_name = st.session_state.edit_episode_profile
+            edit_profile_data = profile_manager.get_episode_profile(edit_profile_name)
+            
+            if edit_profile_data:
+                st.subheader(f"✏️ Edit Episode Profile: {edit_profile_name}")
+                
+                # Profile name (allow renaming)
+                new_profile_name = st.text_input(
+                    "Profile Name:", 
+                    value=edit_profile_name,
+                    key="edit_episode_profile_name"
+                )
+                
+                if speaker_profile_names:
+                    current_speaker_index = 0
+                    if edit_profile_data['speaker_config'] in speaker_profile_names:
+                        current_speaker_index = speaker_profile_names.index(edit_profile_data['speaker_config'])
+                    
+                    speaker_config = st.selectbox(
+                        "Speaker Profile:", 
+                        speaker_profile_names, 
+                        index=current_speaker_index,
+                        key="edit_episode_speaker"
+                    )
+                else:
+                    st.error("⚠️ No speaker profiles found.")
+                    speaker_config = edit_profile_data.get('speaker_config', '')
+                
+                st.markdown("### AI Model Configuration")
+                
+                # Outline Model Configuration
+                st.markdown("**Outline Generation:**")
+                col1, col2 = st.columns(2)
+                with col1:
+                    current_outline_provider = edit_profile_data.get('outline_provider', 'openai')
+                    outline_provider = ProviderChecker.render_provider_selector(
+                        "Outline Provider:",
+                        all_providers,
+                        current_provider=current_outline_provider,
+                        key="edit_episode_outline_provider",
+                        help_text="Choose an AI provider for generating podcast outlines"
+                    )
+                with col2:
+                    # Get default model for selected provider
+                    defaults = ProviderChecker.get_default_models(outline_provider)
+                    default_model = defaults.get("outline", "gpt-4o")
+                    
+                    current_outline_model = edit_profile_data.get('outline_model', default_model)
+                    outline_model = st.text_input(
+                        "Outline Model:", 
+                        value=current_outline_model,
+                        placeholder=default_model,
+                        key="edit_episode_outline_model"
+                    )
+                
+                # Transcript Model Configuration
+                st.markdown("**Transcript Generation:**")
+                col1, col2 = st.columns(2)
+                with col1:
+                    current_transcript_provider = edit_profile_data.get('transcript_provider', 'openai')
+                    transcript_provider = ProviderChecker.render_provider_selector(
+                        "Transcript Provider:",
+                        all_providers,
+                        current_provider=current_transcript_provider,
+                        key="edit_episode_transcript_provider",
+                        help_text="Choose an AI provider for generating podcast transcripts"
+                    )
+                with col2:
+                    # Get default model for selected provider
+                    defaults = ProviderChecker.get_default_models(transcript_provider)
+                    default_model = defaults.get("transcript", "gpt-4o")
+                    
+                    current_transcript_model = edit_profile_data.get('transcript_model', default_model)
+                    transcript_model = st.text_input(
+                        "Transcript Model:", 
+                        value=current_transcript_model,
+                        placeholder=default_model,
+                        key="edit_episode_transcript_model"
+                    )
+                
+                num_segments = st.slider(
+                    "Number of Segments:", 
+                    1, 10, 
+                    value=edit_profile_data.get('num_segments', 4),
+                    key="edit_episode_segments"
+                )
+                
+                default_briefing = st.text_area(
+                    "Default Briefing:", 
+                    value=edit_profile_data.get('default_briefing', ''),
+                    height=100,
+                    key="edit_episode_briefing"
+                )
+                
+                st.markdown("---")
+                
+                # Action buttons
+                col1, col2 = st.columns(2)
+                
+                with col1:
+                    if st.button("✅ Save Changes", type="primary", key="save_episode_changes"):
+                        if not new_profile_name.strip():
+                            st.error("Profile name cannot be empty")
+                        elif new_profile_name != edit_profile_name and new_profile_name in profile_names:
+                            st.error(f"Profile name '{new_profile_name}' already exists")
+                        else:
+                            # Update profile data with provider information
+                            updated_profile_data = {
+                                "speaker_config": speaker_config,
+                                "outline_model": outline_model,
+                                "outline_provider": outline_provider,
+                                "transcript_model": transcript_model,
+                                "transcript_provider": transcript_provider,
+                                "num_segments": num_segments,
+                                "default_briefing": default_briefing
+                            }
+                            
+                            # Validate profile
+                            validation_errors = profile_manager.validate_episode_profile(updated_profile_data)
+                            if validation_errors:
+                                st.error("❌ Validation errors:")
+                                for error in validation_errors:
+                                    st.error(f"• {error}")
+                            else:
+                                # Handle renaming if needed
+                                if new_profile_name != edit_profile_name:
+                                    # Create new profile with new name
+                                    if profile_manager.create_episode_profile(new_profile_name, updated_profile_data):
+                                        # Delete old profile
+                                        if profile_manager.delete_episode_profile(edit_profile_name):
+                                            st.success(f"✅ Profile renamed from '{edit_profile_name}' to '{new_profile_name}' and updated successfully!")
+                                        else:
+                                            st.warning(f"✅ New profile '{new_profile_name}' created, but failed to delete old profile '{edit_profile_name}'")
+                                    else:
+                                        st.error("❌ Failed to create renamed profile")
+                                else:
+                                    # Update existing profile
+                                    if profile_manager.update_episode_profile(edit_profile_name, updated_profile_data):
+                                        st.success(f"✅ Profile '{edit_profile_name}' updated successfully!")
+                                    else:
+                                        st.error("❌ Failed to update profile")
+                                
+                                st.session_state.edit_episode_profile = None
+                                st.rerun()
+                
+                with col2:
+                    if st.button("❌ Cancel Edit", key="cancel_edit_episode"):
+                        st.session_state.edit_episode_profile = None
+                        st.rerun()
+                
+                st.markdown("---")
+            else:
+                st.error(f"Episode profile '{edit_profile_name}' not found")
+                st.session_state.edit_episode_profile = None
+                st.rerun()
+        
+        # Display existing profiles
+        st.subheader("Existing Episode Profiles")
+        
+        if profile_names:
+            # Display as grid
+            cols = st.columns(3)
+            
+            for i, profile_name in enumerate(profile_names):
+                profile_data = profiles["profiles"][profile_name]
+                
+                with cols[i % 3]:
+                    with st.container(border=True):
+                        st.markdown(f"### 📺 {profile_name}")
+                        st.markdown(f"**Speaker:** {profile_data.get('speaker_config', 'N/A')}")
+                        st.markdown(f"**Segments:** {profile_data.get('num_segments', 'N/A')}")
+                        
+                        outline_provider = profile_data.get('outline_provider', 'openai')
+                        outline_model = profile_data.get('outline_model', 'N/A')
+                        st.markdown(f"**Outline:** {outline_provider}/{outline_model}")
+                        
+                        transcript_provider = profile_data.get('transcript_provider', 'openai')
+                        transcript_model = profile_data.get('transcript_model', 'N/A')
+                        st.markdown(f"**Transcript:** {transcript_provider}/{transcript_model}")
+                        
+                        # Action buttons
+                        col1, col2 = st.columns(2)
+                        
+                        with col1:
+                            if st.button("✏️ Edit", key=f"edit_ep_{profile_name}", use_container_width=True):
+                                st.session_state.edit_episode_profile = profile_name
+                                st.rerun()
+                        
+                        with col2:
+                            if st.button("📋 Clone", key=f"clone_ep_{profile_name}", use_container_width=True):
+                                new_name = f"{profile_name}_copy"
+                                if profile_manager.clone_episode_profile(profile_name, new_name):
+                                    st.success(f"✅ Cloned as '{new_name}'")
+                                    st.rerun()
+                                else:
+                                    st.error("❌ Failed to clone")
+                        
+                        # Export button
+                        export_data = profile_manager.export_episode_profiles([profile_name])
+                        st.download_button(
+                            label="💾 Export",
+                            data=json.dumps(export_data, indent=2),
+                            file_name=f"{profile_name}_episode_config.json",
+                            mime="application/json",
+                            key=f"export_ep_{profile_name}",
+                            use_container_width=True
+                        )
+                        
+                        # Delete button
+                        if st.button("🗑️ Delete", key=f"delete_ep_{profile_name}", use_container_width=True):
+                            if profile_manager.delete_episode_profile(profile_name):
+                                st.success(f"✅ Deleted '{profile_name}'")
+                                st.rerun()
+                            else:
+                                st.error("❌ Failed to delete")
+                        
+                        # Show more details in expander
+                        with st.expander("📋 Details"):
+                            st.markdown(f"**Outline Provider:** {profile_data.get('outline_provider', 'openai')}")
+                            st.markdown(f"**Outline Model:** {profile_data.get('outline_model', 'N/A')}")
+                            st.markdown(f"**Transcript Provider:** {profile_data.get('transcript_provider', 'openai')}")
+                            st.markdown(f"**Transcript Model:** {profile_data.get('transcript_model', 'N/A')}")
+                            st.markdown("**Default Briefing:**")
+                            st.text(profile_data.get('default_briefing', 'No briefing set'))
+        else:
+            st.info("No episode profiles found. Create your first profile to get started!")
+    
+    except Exception as e:
+        st.error(f"Error loading episode profiles: {str(e)}")
+        st.markdown("Please check your configuration files and try again.")
+
+def show_generate_podcast_page():
+    """Display the podcast generation page."""
+    st.subheader("🎬 Generate Podcast")
+    st.markdown("Create new podcast episodes")
+    
+    # Initialize managers
+    profile_manager = ProfileManager(working_dir=WORKING_DIR)
+    episode_manager = EpisodeManager(base_output_dir=WORKING_DIR / "output")
+    
+    try:
+        # Load available profiles
+        episode_profiles = profile_manager.get_episode_profile_names()
+        speaker_profiles = profile_manager.get_speaker_profile_names()
+        
+        if not episode_profiles:
+            st.error("⚠️ No episode profiles found. Please create an episode profile first.")
+            if st.button("📺 Go to Episode Profiles"):
+                st.session_state.current_page = "📺 Episode Profiles"
+                st.rerun()
+            return
+        
+        # Content input section
+        st.markdown("### Step 1: Content Collection")
+        
+        # Initialize session state for content pieces
+        if 'content_pieces' not in st.session_state:
+            st.session_state.content_pieces = []
+        
+        # Add new content section
+        with st.expander("➕ Add Content", expanded=len(st.session_state.content_pieces) == 0):
+            content_source = st.radio(
+                "Content Source:",
+                ["Text Input", "File Upload", "URL"],
+                horizontal=True,
+                key="new_content_source"
+            )
+            
+            if content_source == "Text Input":
+                text_content = st.text_area("Enter your content:", height=150, placeholder="Paste your content here...", key="new_text_input")
+                
+                if st.button("📝 Add Text Content", disabled=not text_content.strip()):
+                    if text_content.strip():
+                        content_piece = {
+                            'type': 'text',
+                            'title': f"Text Content {len(st.session_state.content_pieces) + 1}",
+                            'content': text_content.strip(),
+                            'source': 'Direct input'
+                        }
+                        st.session_state.content_pieces.append(content_piece)
+                        st.rerun()
+            
+            elif content_source == "File Upload":
+                uploaded_file = st.file_uploader(
+                    "Upload a file:", 
+                    type=['txt', 'pdf', 'docx', 'md', 'json'],
+                    help="Supported formats: TXT, PDF, DOCX, MD, JSON",
+                    key="new_file_uploader"
+                )
+                
+                if uploaded_file is not None and st.button("📄 Add File Content"):
+                    try:
+                        if ContentExtractor.is_content_core_available():
+                            with st.spinner("Extracting content from file..."):
+                                extracted_content = ContentExtractor.extract_from_uploaded_file(uploaded_file)
+                                content_piece = {
+                                    'type': 'file',
+                                    'title': uploaded_file.name,
+                                    'content': extracted_content,
+                                    'source': f"File: {uploaded_file.name}"
+                                }
+                                st.session_state.content_pieces.append(content_piece)
+                                st.success(f"✅ Added content from {uploaded_file.name}")
+                                st.rerun()
+                        else:
+                            st.error("⚠️ content-core library not available. Install it with: `pip install content-core`")
+                    except Exception as e:
+                        st.error(f"❌ Error extracting content: {str(e)}")
+            
+            else:  # URL
+                url = st.text_input("Enter URL:", placeholder="https://example.com/article", key="new_url_input")
+                
+                if url and st.button("🔗 Add URL Content"):
+                    if ContentExtractor.validate_url(url):
+                        try:
+                            if ContentExtractor.is_content_core_available():
+                                with st.spinner("Extracting content from URL..."):
+                                    extracted_content = run_async_in_streamlit(ContentExtractor.extract_from_url, url)
+                                    content_piece = {
+                                        'type': 'url',
+                                        'title': url,
+                                        'content': extracted_content,
+                                        'source': f"URL: {url}"
+                                    }
+                                    st.session_state.content_pieces.append(content_piece)
+                                    st.success(f"✅ Added content from URL")
+                                    st.rerun()
+                            else:
+                                st.error("⚠️ content-core library not available. Install it with: `pip install content-core`")
+                        except Exception as e:
+                            ErrorHandler.handle_streamlit_error(e, {"url": url})
+                    else:
+                        st.error("❌ Invalid or inaccessible URL")
+        
+        # Display content pieces
+        if st.session_state.content_pieces:
+            st.markdown("### Content Pieces")
+            
+            total_content = ""
+            total_chars = 0
+            total_words = 0
+            
+            for i, piece in enumerate(st.session_state.content_pieces):
+                with st.container(border=True):
+                    col1, col2, col3 = st.columns([3, 1, 1])
+                    
+                    with col1:
+                        # Show content piece info
+                        type_icon = {"text": "📝", "file": "📄", "url": "🔗"}.get(piece['type'], "📄")
+                        st.markdown(f"**{type_icon} {piece['title']}**")
+                        st.markdown(f"*Source: {piece['source']}*")
+                        
+                        # Content stats
+                        piece_stats = ContentExtractor.get_content_stats(piece['content'])
+                        st.markdown(f"📊 {piece_stats['character_count']} chars, {piece_stats['word_count']} words")
+                        
+                        # Preview
+                        with st.expander("👀 Preview"):
+                            preview = ContentExtractor.truncate_content(piece['content'], 300)
+                            st.text(preview)
+                    
+                    with col2:
+                        # Move up/down buttons
+                        if i > 0:
+                            if st.button("⬆️", key=f"move_up_{i}", help="Move up"):
+                                st.session_state.content_pieces[i], st.session_state.content_pieces[i-1] = st.session_state.content_pieces[i-1], st.session_state.content_pieces[i]
+                                st.rerun()
+                        
+                        if i < len(st.session_state.content_pieces) - 1:
+                            if st.button("⬇️", key=f"move_down_{i}", help="Move down"):
+                                st.session_state.content_pieces[i], st.session_state.content_pieces[i+1] = st.session_state.content_pieces[i+1], st.session_state.content_pieces[i]
+                                st.rerun()
+                    
+                    with col3:
+                        # Delete button
+                        if st.button("🗑️", key=f"delete_content_{i}", help="Delete"):
+                            st.session_state.content_pieces.pop(i)
+                            st.rerun()
+                
+                # Add to statistics
+                total_chars += piece_stats['character_count']
+                total_words += piece_stats['word_count']
+            
+            # Actions
+            if st.button("🔄 Clear All Content", type="secondary"):
+                st.session_state.content_pieces = []
+                st.rerun()
+            
+            # Set content for generation (pass array instead of concatenated string)
+            content_pieces = st.session_state.content_pieces
+            content_stats = {
+                'character_count': total_chars,
+                'word_count': total_words,
+                'paragraph_count': len(st.session_state.content_pieces),  # Number of pieces instead of paragraphs
+                'estimated_reading_time': max(1, total_words // 200)
+            }
+        else:
+            st.info("📝 No content added yet. Use the 'Add Content' section above to add text, files, or URLs.")
+            content_pieces = []
+            content_stats = None
+        
+        st.markdown("---")
+        
+        # Configuration section
+        st.markdown("### Step 2: Configuration")
+        
+        col1, col2 = st.columns(2)
+        
+        with col1:
+            episode_profile = st.selectbox(
+                "Episode Profile:",
+                episode_profiles,
+                help="Choose a pre-configured episode profile",
+                key="episode_profile_select"
+            )
+        
+        with col2:
+            use_defaults = st.checkbox("Use profile defaults", value=True, key="use_profile_defaults")
+        
+        # Load selected profile data
+        profile_data = profile_manager.get_episode_profile(episode_profile)
+        
+        if profile_data:
+            st.markdown(f"**Profile Info:** {profile_data.get('default_briefing', 'No description')}")
+            
+            # Override options
+            if not use_defaults:
+                with st.expander("🔧 Override Settings", expanded=True):
+                    speaker_config = st.selectbox(
+                        "Speaker Config:",
+                        speaker_profiles,
+                        index=speaker_profiles.index(profile_data['speaker_config']) if profile_data['speaker_config'] in speaker_profiles else 0
+                    )
+                    
+                    outline_model = st.text_input(
+                        "Outline Model:",
+                        value=profile_data.get('outline_model', 'gpt-4o')
+                    )
+                    
+                    transcript_model = st.text_input(
+                        "Transcript Model:",
+                        value=profile_data.get('transcript_model', 'gpt-4o')
+                    )
+                    
+                    num_segments = st.slider(
+                        "Number of Segments:",
+                        1, 10,
+                        value=profile_data.get('num_segments', 4)
+                    )
+                    
+                    briefing = st.text_area(
+                        "Briefing:",
+                        value=profile_data.get('default_briefing', ''),
+                        height=100
+                    )
+                    
+                    briefing_suffix = st.text_input(
+                        "Briefing Suffix:",
+                        placeholder="Additional instructions..."
+                    )
+            else:
+                # Use profile defaults
+                speaker_config = profile_data['speaker_config']
+                outline_model = profile_data.get('outline_model', 'gpt-4o')
+                transcript_model = profile_data.get('transcript_model', 'gpt-4o')
+                num_segments = profile_data.get('num_segments', 4)
+                briefing = profile_data.get('default_briefing', '')
+                briefing_suffix = ""
+        
+        st.markdown("---")
+        
+        # Briefing editor section
+        st.markdown("### Step 3: Briefing Editor")
+        
+        # Initialize briefing in session state if not exists or if profile changed
+        if 'custom_briefing' not in st.session_state or 'last_episode_profile' not in st.session_state:
+            st.session_state.custom_briefing = briefing
+            st.session_state.last_episode_profile = episode_profile
+        elif st.session_state.last_episode_profile != episode_profile:
+            # Profile changed, update briefing
+            st.session_state.custom_briefing = briefing
+            st.session_state.last_episode_profile = episode_profile
+        
+        # Always show briefing editor
+        col1, col2 = st.columns([3, 1])
+        with col1:
+            custom_briefing = st.text_area(
+                "Edit Briefing:",
+                value=st.session_state.custom_briefing,
+                height=120,
+                help="Edit the briefing that will be sent to the AI model for podcast generation",
+                key="custom_briefing_editor"
+            )
+        with col2:
+            if st.button("🔄 Reset to Default", key="reset_briefing"):
+                st.session_state.custom_briefing = briefing
+                st.rerun()
+        
+        # Update session state
+        st.session_state.custom_briefing = custom_briefing
+        
+        # Show briefing preview
+        if custom_briefing:
+            with st.expander("📋 Briefing Preview"):
+                st.markdown(f"**Final briefing that will be sent to the AI:**")
+                final_briefing = custom_briefing
+                if not use_defaults and briefing_suffix:
+                    final_briefing += f"\n\n{briefing_suffix}"
+                st.text(final_briefing)
+        
+        st.markdown("---")
+        
+        # Output settings section
+        st.markdown("### Step 4: Output Settings")
+        
+        col1, col2 = st.columns(2)
+        
+        with col1:
+            episode_name = st.text_input(
+                "Episode Name:",
+                placeholder="my_awesome_podcast",
+                help="This will be used as the folder name"
+            )
+        
+        with col2:
+            output_dir = st.text_input(
+                "Output Directory:",
+                value="output",
+                help="Base directory for podcast output"
+            )
+        
+        # Check if episode exists
+        if episode_name:
+            episode_exists = episode_manager.check_episode_exists(episode_name)
+            if episode_exists:
+                st.warning(f"⚠️ Episode '{episode_name}' already exists. Generation will overwrite existing files.")
+                overwrite_confirmed = st.checkbox("✅ I understand and want to overwrite", key="overwrite_confirm")
+            else:
+                overwrite_confirmed = True
+        else:
+            overwrite_confirmed = True
+        
+        st.markdown("---")
+        
+        # Generation section
+        col1, col2 = st.columns([2, 1])
+        
+        with col1:
+            # Validate content pieces instead of concatenated content
+            has_valid_content = bool(content_pieces and any(
+                piece.get('content', '').strip() and len(piece.get('content', '').strip()) >= 50 
+                for piece in content_pieces
+            ))
+            
+            can_generate = (
+                has_valid_content and 
+                episode_name and 
+                overwrite_confirmed
+            )
+            
+            if not content_pieces:
+                st.info("📝 Please add content pieces to generate a podcast")
+            elif not has_valid_content:
+                st.error("❌ Content pieces are too short or invalid. Please provide at least 50 characters of meaningful text in at least one piece.")
+            elif not episode_name:
+                st.error("❌ Please provide an episode name")
+            elif not overwrite_confirmed:
+                st.error("❌ Please confirm overwrite to proceed")
+        
+        with col2:
+            if st.button(
+                "🎬 Generate Podcast", 
+                type="primary", 
+                disabled=not can_generate,
+                use_container_width=True
+            ):
+                st.session_state.start_generation = True
+                st.rerun()
+        
+        # Handle podcast generation
+        if st.session_state.get("start_generation", False):
+            st.session_state.start_generation = False
+            
+            # Show generation progress
+            progress_container = st.container()
+            status_container = st.container()
+            
+            progress_bar = progress_container.progress(0)
+            status_text = status_container.empty()
+            
+            try:
+                status_text.text("🚀 Starting podcast generation...")
+                progress_bar.progress(10)
+                
+                # Import podcast creator
+                try:
+                    from podcast_creator import create_podcast, configure
+                    # Configure to use current working directory
+                    configure(working_dir=str(WORKING_DIR))
+                    podcast_creator_available = True
+                except ImportError:
+                    podcast_creator_available = False
+                    st.error("❌ podcast-creator library not available. Please install it first.")
+                    return
+                
+                if podcast_creator_available:
+                    status_text.text("📝 Preparing generation parameters...")
+                    progress_bar.progress(20)
+                    
+                    # Prepare parameters
+                    generation_params = {
+                        "content": content_pieces,
+                        "episode_name": episode_name,
+                        "output_dir": f"{output_dir}/{episode_name}",
+                        "episode_profile": episode_profile
+                    }
+                    
+                    # Add overrides if not using defaults
+                    if not use_defaults:
+                        generation_params.update({
+                            "speaker_config": speaker_config,
+                            "outline_model": outline_model,
+                            "transcript_model": transcript_model,
+                            "num_segments": num_segments,
+                            "briefing": st.session_state.custom_briefing
+                        })
+                        
+                        if briefing_suffix:
+                            generation_params["briefing_suffix"] = briefing_suffix
+                    else:
+                        # Even when using defaults, use the custom briefing if modified
+                        if st.session_state.custom_briefing != briefing:
+                            generation_params["briefing"] = st.session_state.custom_briefing
+                    
+                    status_text.text("🎙️ Generating podcast... This may take several minutes...")
+                    progress_bar.progress(30)
+                    
+                    # Generate podcast
+                    async def generate():
+                        return await create_podcast(**generation_params)
+                    
+                    result = run_async_in_streamlit(generate)
+                    
+                    progress_bar.progress(100)
+                    status_text.text("✅ Podcast generation completed!")
+                    
+                    # Clear content after successful generation
+                    st.session_state.generated_content = ""
+                    st.session_state.content_stats = None
+                    st.session_state.content_pieces = []
+                    
+                    # Show success message
+                    st.success(f"🎉 Podcast '{episode_name}' generated successfully!")
+                    
+                    if 'final_output_file_path' in result:
+                        st.markdown(f"**Audio file:** `{result['final_output_file_path']}`")
+                    
+                    # Quick actions
+                    col1, col2 = st.columns(2)
+                    
+                    with col1:
+                        if st.button("📚 View in Library", type="primary"):
+                            st.session_state.current_page = "📚 Episode Library"
+                            st.session_state.navigate_to_library = True
+                            st.rerun()
+                    
+                    with col2:
+                        if st.button("🎬 Generate Another"):
+                            st.rerun()
+                    
+                    # Clean up progress indicators
+                    progress_bar.empty()
+                    status_text.empty()
+            
+            except Exception as e:
+                # Clean up progress indicators
+                progress_bar.empty()
+                status_text.empty()
+                
+                # Handle the error
+                total_content_length = sum(len(piece.get('content', '')) for piece in content_pieces) if content_pieces else 0
+                ErrorHandler.handle_streamlit_error(e, {
+                    "episode_name": episode_name,
+                    "episode_profile": episode_profile,
+                    "content_pieces_count": len(content_pieces) if content_pieces else 0,
+                    "total_content_length": total_content_length
+                })
+                
+                # Show retry button
+                if st.button("🔄 Retry Generation", type="primary"):
+                    st.session_state.start_generation = True
+                    st.rerun()
+    
+    except Exception as e:
+        st.error(f"Error loading generation page: {str(e)}")
+        st.markdown("Please check your configuration and try again.")
+
+def show_episode_library_page():
+    """Display the episode library and playback page."""
+    st.subheader("📚 Episode Library")
+    st.markdown("Browse and play your generated episodes")
+    
+    # Initialize episode manager
+    episode_manager = EpisodeManager(base_output_dir=WORKING_DIR / "output")
+    
+    try:
+        # Load episodes
+        all_episodes = episode_manager.scan_episodes_directory()
+        
+        if not all_episodes:
+            st.info("📝 No episodes found. Start by generating your first podcast!")
+            if st.button("🎬 Generate Your First Podcast", type="primary"):
+                st.session_state.current_page = "🎬 Generate Podcast"
+                st.rerun()
+            return
+        
+        # Search and filter controls
+        col1, col2, col3 = st.columns([2, 1, 1])
+        
+        with col1:
+            search_query = st.text_input("🔍 Search episodes:", placeholder="Search by name...")
+        
+        with col2:
+            sort_by = st.selectbox("Sort by:", ["Newest", "Oldest", "A-Z", "Duration"])
+        
+        with col3:
+            view_mode = st.radio("View:", ["Grid", "List"], horizontal=True)
+        
+        # Filter and sort episodes
+        filtered_episodes = episode_manager.search_episodes(search_query, all_episodes)
+        sorted_episodes = episode_manager.sort_episodes(filtered_episodes, sort_by)
+        
+        # Show episode count
+        st.markdown(f"**{len(sorted_episodes)} episode(s) found**")
+        st.markdown("---")
+        
+        # Handle selected episode for playback
+        selected_episode = st.session_state.get("selected_episode")
+        
+        # Episode playback section
+        if selected_episode and selected_episode.audio_file:
+            with st.container(border=True):
+                st.markdown(f"### 🎵 Now Playing: {selected_episode.name}")
+                
+                # Audio player
+                if Path(selected_episode.audio_file).exists():
+                    audio_file = open(selected_episode.audio_file, 'rb')
+                    audio_bytes = audio_file.read()
+                    st.audio(audio_bytes, format='audio/mp3')
+                    audio_file.close()
+                    
+                    # Episode details
+                    col1, col2, col3 = st.columns(3)
+                    
+                    with col1:
+                        if selected_episode.duration:
+                            st.metric("Duration", episode_manager.format_duration(selected_episode.duration))
+                    
+                    with col2:
+                        if selected_episode.speakers_count:
+                            st.metric("Speakers", selected_episode.speakers_count)
+                    
+                    with col3:
+                        if selected_episode.file_size:
+                            st.metric("File Size", episode_manager.format_file_size(selected_episode.file_size))
+                    
+                    # Action buttons
+                    col1, col2, col3, col4 = st.columns(4)
+                    
+                    with col1:
+                        if st.button("📄 View Transcript", use_container_width=True):
+                            st.session_state.show_transcript = True
+                            st.rerun()
+                    
+                    with col2:
+                        if st.button("📊 View Outline", use_container_width=True):
+                            st.session_state.show_outline = True
+                            st.rerun()
+                    
+                    with col3:
+                        # Download button
+                        if st.download_button(
+                            label="⬇️ Download",
+                            data=audio_bytes,
+                            file_name=f"{selected_episode.name}.mp3",
+                            mime="audio/mp3",
+                            use_container_width=True
+                        ):
+                            st.success("📥 Download started!")
+                    
+                    with col4:
+                        if st.button("🗑️ Delete", use_container_width=True):
+                            st.session_state.confirm_delete = selected_episode.name
+                            st.rerun()
+                else:
+                    st.error("❌ Audio file not found")
+                
+                # Show transcript
+                if st.session_state.get("show_transcript", False):
+                    if selected_episode.transcript_file and Path(selected_episode.transcript_file).exists():
+                        with st.expander("📄 Transcript", expanded=True):
+                            try:
+                                with open(selected_episode.transcript_file, 'r', encoding='utf-8') as f:
+                                    transcript_data = json.load(f)
+                                
+                                if isinstance(transcript_data, list):
+                                    for i, segment in enumerate(transcript_data):
+                                        if isinstance(segment, dict):
+                                            speaker = segment.get('speaker', f'Speaker {i+1}')
+                                            # Try multiple possible field names for the text content
+                                            text = (segment.get('text') or 
+                                                   segment.get('content') or 
+                                                   segment.get('dialogue') or 
+                                                   segment.get('message') or 
+                                                   segment.get('speech') or '')
+                                            
+                                            # Debug: Show available keys if text is empty
+                                            if not text and st.session_state.get('debug_transcript', False):
+                                                st.warning(f"Debug - Segment {i+1} keys: {list(segment.keys())}")
+                                                st.json(segment)
+                                            
+                                            if text:
+                                                st.markdown(f"**{speaker}:** {text}")
+                                                st.markdown("---")
+                                            else:
+                                                st.markdown(f"**{speaker}:** *[No content found]*")
+                                                st.markdown("---")
+                                else:
+                                    st.text(str(transcript_data))
+                                
+                                # Add debug toggle
+                                if st.checkbox("🐛 Debug Mode - Show Raw Data", key="debug_transcript_toggle"):
+                                    st.session_state.debug_transcript = True
+                                    st.json(transcript_data)
+                                else:
+                                    st.session_state.debug_transcript = False
+                            except Exception as e:
+                                st.error(f"Error loading transcript: {str(e)}")
+                            
+                            if st.button("❌ Close Transcript"):
+                                st.session_state.show_transcript = False
+                                st.rerun()
+                    else:
+                        st.error("❌ Transcript file not found")
+                
+                # Show outline
+                if st.session_state.get("show_outline", False):
+                    if selected_episode.outline_file and Path(selected_episode.outline_file).exists():
+                        with st.expander("📊 Outline", expanded=True):
+                            try:
+                                with open(selected_episode.outline_file, 'r', encoding='utf-8') as f:
+                                    outline_data = json.load(f)
+                                st.json(outline_data)
+                            except Exception as e:
+                                st.error(f"Error loading outline: {str(e)}")
+                            
+                            if st.button("❌ Close Outline"):
+                                st.session_state.show_outline = False
+                                st.rerun()
+                    else:
+                        st.error("❌ Outline file not found")
+                
+                # Stop playback button
+                if st.button("⏹️ Stop Playback"):
+                    st.session_state.selected_episode = None
+                    st.session_state.show_transcript = False
+                    st.session_state.show_outline = False
+                    st.rerun()
+            
+            st.markdown("---")
+        
+        # Handle delete confirmation
+        if st.session_state.get("confirm_delete"):
+            episode_to_delete = st.session_state.confirm_delete
+            
+            st.warning(f"⚠️ Are you sure you want to delete episode '{episode_to_delete}'?")
+            st.markdown("This action cannot be undone and will permanently delete all episode files.")
+            
+            col1, col2 = st.columns(2)
+            
+            with col1:
+                if st.button("✅ Yes, Delete", type="primary"):
+                    # Find the episode to delete
+                    for episode in sorted_episodes:
+                        if episode.name == episode_to_delete:
+                            if episode_manager.delete_episode(episode.path):
+                                st.success(f"✅ Episode '{episode_to_delete}' deleted successfully")
+                                if st.session_state.get("selected_episode") and st.session_state.selected_episode.name == episode_to_delete:
+                                    st.session_state.selected_episode = None
+                                st.session_state.confirm_delete = None
+                                st.rerun()
+                            else:
+                                st.error("❌ Failed to delete episode")
+                            break
+            
+            with col2:
+                if st.button("❌ Cancel"):
+                    st.session_state.confirm_delete = None
+                    st.rerun()
+            
+            st.markdown("---")
+        
+        # Display episodes
+        if view_mode == "Grid":
+            # Grid view
+            cols = st.columns(3)
+            
+            for i, episode in enumerate(sorted_episodes):
+                with cols[i % 3]:
+                    with st.container(border=True):
+                        st.markdown(f"### 🎙️ {episode.name}")
+                        
+                        if episode.created_date:
+                            st.markdown(f"**Created:** {episode.created_date.strftime('%Y-%m-%d %H:%M')}")
+                        
+                        if episode.duration:
+                            st.markdown(f"**Duration:** {episode_manager.format_duration(episode.duration)}")
+                        
+                        if episode.speakers_count:
+                            st.markdown(f"**Speakers:** {episode.speakers_count}")
+                        
+                        if episode.profile_used:
+                            st.markdown(f"**Profile:** {episode.profile_used}")
+                        
+                        # Action buttons
+                        if episode.audio_file and st.button("▶️ Play", key=f"play_grid_{i}", use_container_width=True):
+                            st.session_state.selected_episode = episode
+                            st.rerun()
+                        
+                        col1, col2 = st.columns(2)
+                        
+                        with col1:
+                            if episode.transcript_file and st.button("📄", key=f"transcript_grid_{i}", help="View Transcript"):
+                                st.session_state.selected_episode = episode
+                                st.session_state.show_transcript = True
+                                st.rerun()
+                        
+                        with col2:
+                            if st.button("🗑️", key=f"delete_grid_{i}", help="Delete Episode"):
+                                st.session_state.confirm_delete = episode.name
+                                st.rerun()
+        
+        else:
+            # List view
+            for i, episode in enumerate(sorted_episodes):
+                with st.container(border=True):
+                    col1, col2, col3 = st.columns([3, 2, 1])
+                    
+                    with col1:
+                        st.markdown(f"### 🎙️ {episode.name}")
+                        if episode.created_date:
+                            st.markdown(f"*Created: {episode.created_date.strftime('%Y-%m-%d %H:%M')}*")
+                    
+                    with col2:
+                        info_lines = []
+                        if episode.duration:
+                            info_lines.append(f"Duration: {episode_manager.format_duration(episode.duration)}")
+                        if episode.speakers_count:
+                            info_lines.append(f"Speakers: {episode.speakers_count}")
+                        if episode.profile_used:
+                            info_lines.append(f"Profile: {episode.profile_used}")
+                        
+                        for line in info_lines:
+                            st.markdown(line)
+                    
+                    with col3:
+                        if episode.audio_file and st.button("▶️ Play", key=f"play_list_{i}"):
+                            st.session_state.selected_episode = episode
+                            st.rerun()
+                        
+                        if episode.transcript_file and st.button("📄 Transcript", key=f"transcript_list_{i}"):
+                            st.session_state.selected_episode = episode
+                            st.session_state.show_transcript = True
+                            st.rerun()
+                        
+                        if st.button("🗑️ Delete", key=f"delete_list_{i}"):
+                            st.session_state.confirm_delete = episode.name
+                            st.rerun()
+        
+        # Library statistics
+        if sorted_episodes:
+            with st.expander("📊 Library Statistics", expanded=False):
+                stats = episode_manager.get_episodes_stats()
+                
+                col1, col2, col3, col4 = st.columns(4)
+                
+                with col1:
+                    st.metric("Total Episodes", stats['total_episodes'])
+                
+                with col2:
+                    if stats['total_duration'] > 0:
+                        total_hours = stats['total_duration'] / 3600
+                        st.metric("Total Duration", f"{total_hours:.1f} hours")
+                
+                with col3:
+                    if stats['average_duration'] > 0:
+                        st.metric("Average Duration", episode_manager.format_duration(stats['average_duration']))
+                
+                with col4:
+                    if stats['total_size'] > 0:
+                        st.metric("Total Size", episode_manager.format_file_size(stats['total_size']))
+    
+    except Exception as e:
+        st.error(f"Error loading episode library: {str(e)}")
+        st.markdown("Please check your output directory and try again.")
+
+if __name__ == "__main__":
+    main()

--- a/src/podcast_creator/resources/streamlit_app/utils/__init__.py
+++ b/src/podcast_creator/resources/streamlit_app/utils/__init__.py
@@ -1,0 +1,21 @@
+"""
+Utilities package for the Podcast Creator Studio Streamlit app.
+"""
+
+from .episode_manager import EpisodeManager
+from .profile_manager import ProfileManager
+from .content_extractor import ContentExtractor
+from .async_helpers import run_async_in_streamlit
+from .error_handler import ErrorHandler
+from .voice_provider import VoiceProvider
+from .provider_checker import ProviderChecker
+
+__all__ = [
+    'EpisodeManager',
+    'ProfileManager', 
+    'ContentExtractor',
+    'run_async_in_streamlit',
+    'ErrorHandler',
+    'VoiceProvider',
+    'ProviderChecker'
+]

--- a/src/podcast_creator/resources/streamlit_app/utils/async_helpers.py
+++ b/src/podcast_creator/resources/streamlit_app/utils/async_helpers.py
@@ -1,0 +1,289 @@
+"""
+Async helpers for running async functions in Streamlit.
+
+Provides utilities to handle async operations in Streamlit apps.
+"""
+
+import asyncio
+import threading
+from typing import Any, Callable, Coroutine, Optional
+import streamlit as st
+from concurrent.futures import ThreadPoolExecutor
+import time
+
+
+def run_async_in_streamlit(async_func: Callable[..., Coroutine], *args, **kwargs) -> Any:
+    """
+    Run an async function in Streamlit.
+    
+    Args:
+        async_func: Async function to run
+        *args: Arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function
+        
+    Returns:
+        Result of the async function
+    """
+    try:
+        # Try to get the current event loop
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # If we're already in an event loop, we need to run in a new thread
+            with ThreadPoolExecutor() as executor:
+                future = executor.submit(asyncio.run, async_func(*args, **kwargs))
+                return future.result()
+        else:
+            # If no event loop is running, we can run directly
+            return loop.run_until_complete(async_func(*args, **kwargs))
+    except RuntimeError:
+        # No event loop exists, create a new one
+        return asyncio.run(async_func(*args, **kwargs))
+
+
+class AsyncTaskManager:
+    """Manager for handling async tasks with progress tracking."""
+    
+    def __init__(self):
+        self.tasks = {}
+        self.results = {}
+        self.errors = {}
+        self.progress = {}
+    
+    def run_task(self, task_id: str, async_func: Callable, *args, **kwargs) -> None:
+        """
+        Run an async task with progress tracking.
+        
+        Args:
+            task_id: Unique identifier for the task
+            async_func: Async function to run
+            *args: Arguments to pass to the function
+            **kwargs: Keyword arguments to pass to the function
+        """
+        def run_in_thread():
+            try:
+                self.progress[task_id] = {"status": "running", "progress": 0}
+                result = asyncio.run(async_func(*args, **kwargs))
+                self.results[task_id] = result
+                self.progress[task_id] = {"status": "completed", "progress": 100}
+            except Exception as e:
+                self.errors[task_id] = str(e)
+                self.progress[task_id] = {"status": "error", "progress": 0}
+        
+        thread = threading.Thread(target=run_in_thread)
+        thread.start()
+        self.tasks[task_id] = thread
+    
+    def get_task_status(self, task_id: str) -> dict:
+        """Get the status of a task."""
+        return self.progress.get(task_id, {"status": "not_found", "progress": 0})
+    
+    def get_task_result(self, task_id: str) -> Any:
+        """Get the result of a completed task."""
+        return self.results.get(task_id)
+    
+    def get_task_error(self, task_id: str) -> Optional[str]:
+        """Get the error from a failed task."""
+        return self.errors.get(task_id)
+    
+    def is_task_running(self, task_id: str) -> bool:
+        """Check if a task is currently running."""
+        return task_id in self.tasks and self.tasks[task_id].is_alive()
+    
+    def is_task_completed(self, task_id: str) -> bool:
+        """Check if a task has completed successfully."""
+        return task_id in self.results
+    
+    def is_task_failed(self, task_id: str) -> bool:
+        """Check if a task has failed."""
+        return task_id in self.errors
+    
+    def cleanup_task(self, task_id: str) -> None:
+        """Clean up task data."""
+        if task_id in self.tasks:
+            del self.tasks[task_id]
+        if task_id in self.results:
+            del self.results[task_id]
+        if task_id in self.errors:
+            del self.errors[task_id]
+        if task_id in self.progress:
+            del self.progress[task_id]
+
+
+class StreamlitAsyncContext:
+    """Context manager for async operations in Streamlit."""
+    
+    def __init__(self, progress_bar: bool = True, status_text: bool = True):
+        self.progress_bar = progress_bar
+        self.status_text = status_text
+        self.progress_bar_obj = None
+        self.status_text_obj = None
+    
+    def __enter__(self):
+        if self.progress_bar:
+            self.progress_bar_obj = st.progress(0)
+        if self.status_text:
+            self.status_text_obj = st.empty()
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.progress_bar_obj:
+            self.progress_bar_obj.empty()
+        if self.status_text_obj:
+            self.status_text_obj.empty()
+    
+    def update_progress(self, progress: float, status: str = ""):
+        """Update the progress bar and status text."""
+        if self.progress_bar_obj:
+            self.progress_bar_obj.progress(progress)
+        if self.status_text_obj and status:
+            self.status_text_obj.text(status)
+
+
+def create_async_task_with_progress(
+    async_func: Callable, 
+    progress_callback: Optional[Callable] = None,
+    *args, 
+    **kwargs
+) -> Callable:
+    """
+    Create an async task wrapper that supports progress reporting.
+    
+    Args:
+        async_func: The async function to wrap
+        progress_callback: Optional callback for progress updates
+        *args: Arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function
+        
+    Returns:
+        Wrapped function that can be executed
+    """
+    async def wrapper():
+        if progress_callback:
+            progress_callback(0, "Starting task...")
+        
+        try:
+            result = await async_func(*args, **kwargs)
+            if progress_callback:
+                progress_callback(100, "Task completed!")
+            return result
+        except Exception as e:
+            if progress_callback:
+                progress_callback(0, f"Task failed: {str(e)}")
+            raise
+    
+    return wrapper
+
+
+def run_async_with_progress(
+    async_func: Callable,
+    progress_container,
+    status_container,
+    *args,
+    **kwargs
+) -> Any:
+    """
+    Run an async function with progress display in Streamlit.
+    
+    Args:
+        async_func: Async function to run
+        progress_container: Streamlit container for progress bar
+        status_container: Streamlit container for status text
+        *args: Arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function
+        
+    Returns:
+        Result of the async function
+    """
+    progress_bar = progress_container.progress(0)
+    status_text = status_container.empty()
+    
+    def update_progress(progress: float, status: str = ""):
+        progress_bar.progress(progress)
+        if status:
+            status_text.text(status)
+    
+    try:
+        # Create wrapper with progress callback
+        async def wrapper():
+            update_progress(0, "Starting...")
+            try:
+                result = await async_func(*args, **kwargs)
+                update_progress(100, "Completed!")
+                return result
+            except Exception as e:
+                update_progress(0, f"Failed: {str(e)}")
+                raise
+        
+        # Run the async function
+        result = run_async_in_streamlit(wrapper)
+        
+        # Clean up progress indicators
+        time.sleep(1)  # Give user time to see completion
+        progress_bar.empty()
+        status_text.empty()
+        
+        return result
+        
+    except Exception as e:
+        # Clean up progress indicators on error
+        progress_bar.empty()
+        status_text.empty()
+        raise
+
+
+def handle_async_errors(async_func: Callable) -> Callable:
+    """
+    Decorator to handle async errors in Streamlit.
+    
+    Args:
+        async_func: Async function to wrap
+        
+    Returns:
+        Wrapped function with error handling
+    """
+    async def wrapper(*args, **kwargs):
+        try:
+            return await async_func(*args, **kwargs)
+        except Exception as e:
+            st.error(f"An error occurred: {str(e)}")
+            st.error("Please check your configuration and try again.")
+            raise
+    
+    return wrapper
+
+
+# Global task manager instance
+_task_manager = AsyncTaskManager()
+
+
+def get_task_manager() -> AsyncTaskManager:
+    """Get the global task manager instance."""
+    return _task_manager
+
+
+def run_background_task(task_id: str, async_func: Callable, *args, **kwargs) -> None:
+    """
+    Run an async task in the background.
+    
+    Args:
+        task_id: Unique identifier for the task
+        async_func: Async function to run
+        *args: Arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function
+    """
+    _task_manager.run_task(task_id, async_func, *args, **kwargs)
+
+
+def get_background_task_status(task_id: str) -> dict:
+    """Get the status of a background task."""
+    return _task_manager.get_task_status(task_id)
+
+
+def get_background_task_result(task_id: str) -> Any:
+    """Get the result of a completed background task."""
+    return _task_manager.get_task_result(task_id)
+
+
+def cleanup_background_task(task_id: str) -> None:
+    """Clean up a background task."""
+    _task_manager.cleanup_task(task_id)

--- a/src/podcast_creator/resources/streamlit_app/utils/content_extractor.py
+++ b/src/podcast_creator/resources/streamlit_app/utils/content_extractor.py
@@ -1,0 +1,312 @@
+"""
+Content extraction utilities for the Podcast Creator Studio.
+
+Handles content extraction from various sources using content-core library.
+"""
+
+import asyncio
+from typing import Optional, Union, Dict, Any, List
+import streamlit as st
+import requests
+from pathlib import Path
+
+try:
+    from content_core import extract_content
+    CONTENT_CORE_AVAILABLE = True
+except ImportError:
+    CONTENT_CORE_AVAILABLE = False
+
+
+class ContentExtractor:
+    """Content extraction utility using content-core library."""
+    
+    @staticmethod
+    def is_content_core_available() -> bool:
+        """Check if content-core library is available."""
+        return CONTENT_CORE_AVAILABLE
+    
+    @staticmethod
+    async def extract_from_url(url: str) -> str:
+        """
+        Extract content from a URL using content-core.
+        
+        Args:
+            url: URL to extract content from
+            
+        Returns:
+            Extracted content as string
+            
+        Raises:
+            ImportError: If content-core is not available
+            Exception: If extraction fails
+        """
+        if not CONTENT_CORE_AVAILABLE:
+            raise ImportError(
+                "content-core library is required for URL extraction. "
+                "Please install it using: pip install content-core"
+            )
+        
+        try:
+            result = await extract_content(dict(url=url))
+            content = result.content if hasattr(result, 'content') else str(result)
+            if not content or not content.strip():
+                raise Exception("No content extracted from URL")
+            return content
+        except Exception as e:
+            raise Exception(f"Failed to extract content from URL: {str(e)}")
+    
+    @staticmethod
+    async def extract_from_file(file_path: str) -> str:
+        """
+        Extract content from a file using content-core.
+        
+        Args:
+            file_path: Path to the file to extract content from
+            
+        Returns:
+            Extracted content as string
+            
+        Raises:
+            ImportError: If content-core is not available
+            FileNotFoundError: If file doesn't exist
+            Exception: If extraction fails
+        """
+        if not CONTENT_CORE_AVAILABLE:
+            raise ImportError(
+                "content-core library is required for file extraction. "
+                "Please install it using: pip install content-core"
+            )
+        
+        file_path_obj = Path(file_path)
+        if not file_path_obj.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        
+        try:
+            result = await extract_content({"file_path": file_path})
+            content = result.content if hasattr(result, 'content') else str(result)
+            if not content or not content.strip():
+                raise Exception("No content extracted from file")
+            return content
+        except Exception as e:
+            raise Exception(f"Failed to extract content from file: {str(e)}")
+    
+    @staticmethod
+    def extract_from_text(text: str) -> str:
+        """
+        Pass through text content directly.
+        
+        Args:
+            text: Text content to pass through
+            
+        Returns:
+            The same text content
+        """
+        return text
+    
+    @staticmethod
+    def extract_from_uploaded_file(uploaded_file) -> str:
+        """
+        Extract content from a Streamlit uploaded file.
+        
+        Args:
+            uploaded_file: Streamlit UploadedFile object
+            
+        Returns:
+            Extracted content as string
+        """
+        try:
+            # For text files, read directly
+            if uploaded_file.type == "text/plain":
+                return uploaded_file.read().decode("utf-8")
+            
+            # For other file types, we would need content-core
+            # For now, save to temp file and use content-core
+            if not CONTENT_CORE_AVAILABLE:
+                raise ImportError(
+                    "content-core library is required for file extraction. "
+                    "Please install it using: pip install content-core"
+                )
+            
+            # Save uploaded file to temporary location
+            import tempfile
+            with tempfile.NamedTemporaryFile(delete=False, suffix=Path(uploaded_file.name).suffix) as tmp_file:
+                tmp_file.write(uploaded_file.read())
+                tmp_file_path = tmp_file.name
+            
+            try:
+                # Extract content using content-core
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                result = loop.run_until_complete(
+                    extract_content({"file_path": tmp_file_path})
+                )
+                loop.close()
+                content = result.content if hasattr(result, 'content') else str(result)
+                if not content or not content.strip():
+                    raise Exception("No content extracted from file")
+                return content
+            finally:
+                # Clean up temporary file
+                Path(tmp_file_path).unlink(missing_ok=True)
+                
+        except Exception as e:
+            raise Exception(f"Failed to extract content from uploaded file: {str(e)}")
+    
+    @classmethod
+    async def extract_content(cls, source: Union[str, Dict[str, Any]]) -> str:
+        """
+        Extract content from various sources.
+        
+        Args:
+            source: Can be:
+                - A string (treated as direct text)
+                - A dict with 'url' key (for URL extraction)
+                - A dict with 'file_path' key (for file extraction)
+        
+        Returns:
+            Extracted content as string
+            
+        Raises:
+            ValueError: If source format is invalid
+            Exception: If extraction fails
+        """
+        if isinstance(source, str):
+            return cls.extract_from_text(source)
+        elif isinstance(source, dict):
+            if 'url' in source:
+                return await cls.extract_from_url(source['url'])
+            elif 'file_path' in source:
+                return await cls.extract_from_file(source['file_path'])
+            else:
+                raise ValueError("Dictionary source must contain 'url' or 'file_path' key")
+        else:
+            raise ValueError(
+                "Source must be a string (direct text) or dict with 'url'/'file_path' key"
+            )
+    
+    @staticmethod
+    def validate_content(content: str) -> bool:
+        """
+        Validate that content is suitable for podcast generation.
+        
+        Args:
+            content: Content to validate
+            
+        Returns:
+            True if content is valid, False otherwise
+        """
+        if not content or not content.strip():
+            return False
+        
+        # Check minimum length (at least 50 characters)
+        if len(content.strip()) < 50:
+            return False
+        
+        # Check that it's not just whitespace or special characters
+        if not any(c.isalnum() for c in content):
+            return False
+        
+        return True
+    
+    @staticmethod
+    def get_content_stats(content: str) -> Dict[str, Any]:
+        """
+        Get statistics about the content.
+        
+        Args:
+            content: Content to analyze
+            
+        Returns:
+            Dictionary with content statistics
+        """
+        if not content:
+            return {
+                'character_count': 0,
+                'word_count': 0,
+                'paragraph_count': 0,
+                'estimated_reading_time': 0
+            }
+        
+        # Basic stats
+        character_count = len(content)
+        word_count = len(content.split())
+        paragraph_count = len([p for p in content.split('\n\n') if p.strip()])
+        
+        # Estimated reading time (average 200 words per minute)
+        estimated_reading_time = max(1, word_count // 200)
+        
+        return {
+            'character_count': character_count,
+            'word_count': word_count,
+            'paragraph_count': paragraph_count,
+            'estimated_reading_time': estimated_reading_time
+        }
+    
+    @staticmethod
+    def truncate_content(content: str, max_length: int = 1000) -> str:
+        """
+        Truncate content to a maximum length for preview.
+        
+        Args:
+            content: Content to truncate
+            max_length: Maximum length in characters
+            
+        Returns:
+            Truncated content
+        """
+        if len(content) <= max_length:
+            return content
+        
+        # Try to truncate at word boundary
+        truncated = content[:max_length]
+        last_space = truncated.rfind(' ')
+        
+        if last_space > max_length * 0.8:  # If we can find a good word boundary
+            truncated = truncated[:last_space]
+        
+        return truncated + "..."
+    
+    @staticmethod
+    def validate_url(url: str) -> bool:
+        """
+        Validate that a URL is accessible.
+        
+        Args:
+            url: URL to validate
+            
+        Returns:
+            True if URL is accessible, False otherwise
+        """
+        try:
+            response = requests.head(url, timeout=10)
+            return response.status_code == 200
+        except Exception:
+            return False
+    
+    @staticmethod
+    def get_supported_file_types() -> List[str]:
+        """
+        Get list of supported file types for extraction.
+        
+        Returns:
+            List of supported file extensions
+        """
+        # These are common file types that content-core typically supports
+        return [
+            '.txt', '.md', '.pdf', '.docx', '.doc', '.rtf',
+            '.html', '.htm', '.csv', '.json', '.xml'
+        ]
+    
+    @staticmethod
+    def is_file_type_supported(file_name: str) -> bool:
+        """
+        Check if a file type is supported for extraction.
+        
+        Args:
+            file_name: Name of the file to check
+            
+        Returns:
+            True if file type is supported, False otherwise
+        """
+        file_extension = Path(file_name).suffix.lower()
+        return file_extension in ContentExtractor.get_supported_file_types()

--- a/src/podcast_creator/resources/streamlit_app/utils/episode_manager.py
+++ b/src/podcast_creator/resources/streamlit_app/utils/episode_manager.py
@@ -1,0 +1,380 @@
+"""
+Episode management utilities for the Podcast Creator Studio.
+
+Handles episode discovery, metadata extraction, and file operations.
+"""
+
+import os
+import json
+import shutil
+from pathlib import Path
+from typing import List, Dict, Optional, Any
+from datetime import datetime
+from dataclasses import dataclass, asdict
+import streamlit as st
+
+try:
+    from pydub import AudioSegment
+    PYDUB_AVAILABLE = True
+except ImportError:
+    PYDUB_AVAILABLE = False
+
+
+@dataclass
+class EpisodeInfo:
+    """Information about a podcast episode."""
+    name: str
+    path: str
+    audio_file: Optional[str] = None
+    transcript_file: Optional[str] = None
+    outline_file: Optional[str] = None
+    created_date: Optional[datetime] = None
+    duration: Optional[float] = None
+    profile_used: Optional[str] = None
+    speakers_count: Optional[int] = None
+    segments_count: Optional[int] = None
+    file_size: Optional[int] = None
+
+
+class EpisodeManager:
+    """Manages podcast episodes including discovery, metadata, and file operations."""
+    
+    def __init__(self, base_output_dir: str = "output"):
+        """
+        Initialize the episode manager.
+        
+        Args:
+            base_output_dir: Base directory where episodes are stored
+        """
+        self.base_output_dir = Path(base_output_dir)
+        self.base_output_dir.mkdir(exist_ok=True)
+    
+    def scan_episodes_directory(self) -> List[EpisodeInfo]:
+        """
+        Scan the output directory for existing episodes.
+        
+        Returns:
+            List of EpisodeInfo objects for found episodes
+        """
+        episodes = []
+        
+        if not self.base_output_dir.exists():
+            return episodes
+        
+        for episode_dir in self.base_output_dir.iterdir():
+            if episode_dir.is_dir():
+                try:
+                    episode_info = self.get_episode_info(episode_dir)
+                    if episode_info:
+                        episodes.append(episode_info)
+                except Exception as e:
+                    st.warning(f"Error reading episode {episode_dir.name}: {e}")
+        
+        # Sort by creation date (newest first)
+        episodes.sort(key=lambda x: x.created_date or datetime.min, reverse=True)
+        return episodes
+    
+    def get_episode_info(self, episode_path: Path) -> Optional[EpisodeInfo]:
+        """
+        Extract episode information from an episode directory.
+        
+        Args:
+            episode_path: Path to the episode directory
+            
+        Returns:
+            EpisodeInfo object if valid episode found, None otherwise
+        """
+        if not episode_path.exists() or not episode_path.is_dir():
+            return None
+        
+        # Look for expected files
+        audio_dir = episode_path / "audio"
+        clips_dir = episode_path / "clips"
+        
+        # Find audio file
+        audio_file = None
+        if audio_dir.exists():
+            for audio_path in audio_dir.glob("*.mp3"):
+                audio_file = str(audio_path)
+                break
+        
+        # Find transcript file
+        transcript_file = None
+        transcript_path = episode_path / "transcript.json"
+        if transcript_path.exists():
+            transcript_file = str(transcript_path)
+        
+        # Find outline file
+        outline_file = None
+        outline_path = episode_path / "outline.json"
+        if outline_path.exists():
+            outline_file = str(outline_path)
+        
+        # Get creation date from directory
+        created_date = None
+        try:
+            created_date = datetime.fromtimestamp(episode_path.stat().st_ctime)
+        except Exception:
+            pass
+        
+        # Get audio duration
+        duration = None
+        if audio_file and PYDUB_AVAILABLE:
+            try:
+                audio = AudioSegment.from_file(audio_file)
+                duration = len(audio) / 1000.0  # Convert to seconds
+            except Exception:
+                pass
+        
+        # Get profile information from transcript
+        profile_used = None
+        speakers_count = None
+        segments_count = None
+        
+        if transcript_file:
+            try:
+                with open(transcript_file, 'r', encoding='utf-8') as f:
+                    transcript_data = json.load(f)
+                    
+                    # Extract speakers count
+                    speakers = set()
+                    if isinstance(transcript_data, list):
+                        for segment in transcript_data:
+                            if isinstance(segment, dict) and 'speaker' in segment:
+                                speakers.add(segment['speaker'])
+                        speakers_count = len(speakers)
+                        segments_count = len(transcript_data)
+                    elif isinstance(transcript_data, dict):
+                        # Handle different transcript formats
+                        if 'segments' in transcript_data:
+                            segments = transcript_data['segments']
+                            for segment in segments:
+                                if 'speaker' in segment:
+                                    speakers.add(segment['speaker'])
+                            speakers_count = len(speakers)
+                            segments_count = len(segments)
+            except Exception:
+                pass
+        
+        # Get file size
+        file_size = None
+        if audio_file:
+            try:
+                file_size = Path(audio_file).stat().st_size
+            except Exception:
+                pass
+        
+        return EpisodeInfo(
+            name=episode_path.name,
+            path=str(episode_path),
+            audio_file=audio_file,
+            transcript_file=transcript_file,
+            outline_file=outline_file,
+            created_date=created_date,
+            duration=duration,
+            profile_used=profile_used,
+            speakers_count=speakers_count,
+            segments_count=segments_count,
+            file_size=file_size
+        )
+    
+    def get_audio_duration(self, audio_path: str) -> Optional[float]:
+        """
+        Get the duration of an audio file in seconds.
+        
+        Args:
+            audio_path: Path to the audio file
+            
+        Returns:
+            Duration in seconds, or None if unable to determine
+        """
+        if not PYDUB_AVAILABLE:
+            return None
+        
+        try:
+            audio = AudioSegment.from_file(audio_path)
+            return len(audio) / 1000.0
+        except Exception:
+            return None
+    
+    def delete_episode(self, episode_path: str) -> bool:
+        """
+        Delete an episode directory and all its contents.
+        
+        Args:
+            episode_path: Path to the episode directory
+            
+        Returns:
+            True if deletion was successful, False otherwise
+        """
+        try:
+            episode_dir = Path(episode_path)
+            if episode_dir.exists() and episode_dir.is_dir():
+                shutil.rmtree(episode_dir)
+                return True
+            return False
+        except Exception as e:
+            st.error(f"Error deleting episode: {e}")
+            return False
+    
+    def download_episode(self, episode_path: str, download_path: str) -> bool:
+        """
+        Copy an episode's audio file to a download location.
+        
+        Args:
+            episode_path: Path to the episode directory
+            download_path: Where to copy the audio file
+            
+        Returns:
+            True if download was successful, False otherwise
+        """
+        try:
+            episode_dir = Path(episode_path)
+            audio_dir = episode_dir / "audio"
+            
+            if not audio_dir.exists():
+                return False
+            
+            # Find the audio file
+            audio_file = None
+            for audio_path in audio_dir.glob("*.mp3"):
+                audio_file = audio_path
+                break
+            
+            if not audio_file:
+                return False
+            
+            # Copy the file
+            shutil.copy2(audio_file, download_path)
+            return True
+            
+        except Exception as e:
+            st.error(f"Error downloading episode: {e}")
+            return False
+    
+    def check_episode_exists(self, episode_name: str) -> bool:
+        """
+        Check if an episode with the given name already exists.
+        
+        Args:
+            episode_name: Name of the episode to check
+            
+        Returns:
+            True if episode exists, False otherwise
+        """
+        episode_path = self.base_output_dir / episode_name
+        return episode_path.exists() and episode_path.is_dir()
+    
+    def get_episodes_stats(self) -> Dict[str, Any]:
+        """
+        Get statistics about all episodes.
+        
+        Returns:
+            Dictionary with episode statistics
+        """
+        episodes = self.scan_episodes_directory()
+        
+        total_episodes = len(episodes)
+        total_duration = 0
+        total_size = 0
+        
+        for episode in episodes:
+            if episode.duration:
+                total_duration += episode.duration
+            if episode.file_size:
+                total_size += episode.file_size
+        
+        return {
+            'total_episodes': total_episodes,
+            'total_duration': total_duration,
+            'total_size': total_size,
+            'average_duration': total_duration / total_episodes if total_episodes > 0 else 0
+        }
+    
+    def search_episodes(self, query: str, episodes: List[EpisodeInfo]) -> List[EpisodeInfo]:
+        """
+        Search episodes by name or other criteria.
+        
+        Args:
+            query: Search query
+            episodes: List of episodes to search
+            
+        Returns:
+            Filtered list of episodes
+        """
+        if not query:
+            return episodes
+        
+        query_lower = query.lower()
+        filtered_episodes = []
+        
+        for episode in episodes:
+            if query_lower in episode.name.lower():
+                filtered_episodes.append(episode)
+        
+        return filtered_episodes
+    
+    def sort_episodes(self, episodes: List[EpisodeInfo], sort_by: str) -> List[EpisodeInfo]:
+        """
+        Sort episodes by various criteria.
+        
+        Args:
+            episodes: List of episodes to sort
+            sort_by: Sorting criteria ('Newest', 'Oldest', 'A-Z', 'Duration')
+            
+        Returns:
+            Sorted list of episodes
+        """
+        if sort_by == "Newest":
+            return sorted(episodes, key=lambda x: x.created_date or datetime.min, reverse=True)
+        elif sort_by == "Oldest":
+            return sorted(episodes, key=lambda x: x.created_date or datetime.min)
+        elif sort_by == "A-Z":
+            return sorted(episodes, key=lambda x: x.name.lower())
+        elif sort_by == "Duration":
+            return sorted(episodes, key=lambda x: x.duration or 0, reverse=True)
+        else:
+            return episodes
+    
+    def format_duration(self, duration: Optional[float]) -> str:
+        """
+        Format duration in seconds to a human-readable string.
+        
+        Args:
+            duration: Duration in seconds
+            
+        Returns:
+            Formatted duration string
+        """
+        if duration is None:
+            return "Unknown"
+        
+        minutes = int(duration // 60)
+        seconds = int(duration % 60)
+        
+        if minutes > 0:
+            return f"{minutes}:{seconds:02d}"
+        else:
+            return f"0:{seconds:02d}"
+    
+    def format_file_size(self, size: Optional[int]) -> str:
+        """
+        Format file size in bytes to a human-readable string.
+        
+        Args:
+            size: File size in bytes
+            
+        Returns:
+            Formatted file size string
+        """
+        if size is None:
+            return "Unknown"
+        
+        if size < 1024:
+            return f"{size} B"
+        elif size < 1024 * 1024:
+            return f"{size / 1024:.1f} KB"
+        elif size < 1024 * 1024 * 1024:
+            return f"{size / (1024 * 1024):.1f} MB"
+        else:
+            return f"{size / (1024 * 1024 * 1024):.1f} GB"

--- a/src/podcast_creator/resources/streamlit_app/utils/error_handler.py
+++ b/src/podcast_creator/resources/streamlit_app/utils/error_handler.py
@@ -1,0 +1,342 @@
+"""
+Error handling utilities for the Podcast Creator Studio.
+
+Provides consistent error handling and user-friendly error messages.
+"""
+
+import traceback
+from typing import Optional, Dict, Any, List
+import streamlit as st
+from enum import Enum
+
+
+class ErrorType(Enum):
+    """Types of errors that can occur in the application."""
+    NETWORK_ERROR = "network_error"
+    FILE_ERROR = "file_error"
+    CONTENT_ERROR = "content_error"
+    PROFILE_ERROR = "profile_error"
+    GENERATION_ERROR = "generation_error"
+    VALIDATION_ERROR = "validation_error"
+    IMPORT_ERROR = "import_error"
+    UNKNOWN_ERROR = "unknown_error"
+
+
+class ErrorHandler:
+    """Handles errors and provides user-friendly messages."""
+    
+    @staticmethod
+    def handle_generation_error(error: Exception) -> str:
+        """
+        Handle podcast generation errors.
+        
+        Args:
+            error: The exception that occurred
+            
+        Returns:
+            User-friendly error message
+        """
+        error_str = str(error).lower()
+        
+        # API-related errors
+        if "api" in error_str or "timeout" in error_str or "rate limit" in error_str:
+            return ErrorHandler._format_api_error(error)
+        
+        # Content-related errors
+        if "content" in error_str or "empty" in error_str:
+            return ErrorHandler._format_content_error(error)
+        
+        # Configuration errors
+        if "config" in error_str or "profile" in error_str:
+            return ErrorHandler._format_config_error(error)
+        
+        # Generic error
+        return ErrorHandler._format_generic_error(error)
+    
+    @staticmethod
+    def _format_api_error(error: Exception) -> str:
+        """Format API-related errors."""
+        error_str = str(error).lower()
+        
+        if "timeout" in error_str:
+            return (
+                "⏱️ **Request Timeout**\n\n"
+                "The AI service took too long to respond. This can happen when:\n"
+                "• The service is experiencing high load\n"
+                "• Your internet connection is slow\n"
+                "• The content is very long\n\n"
+                "**What to try:**\n"
+                "• Click 'Retry' to try again\n"
+                "• Check your internet connection\n"
+                "• Try with shorter content\n"
+                "• Wait a few minutes and try again"
+            )
+        
+        elif "rate limit" in error_str:
+            return (
+                "🚫 **Rate Limit Exceeded**\n\n"
+                "You've exceeded the API rate limit. This happens when:\n"
+                "• Too many requests in a short time\n"
+                "• Your API quota is exhausted\n\n"
+                "**What to try:**\n"
+                "• Wait a few minutes and try again\n"
+                "• Check your API usage and limits\n"
+                "• Consider upgrading your API plan"
+            )
+        
+        elif "authentication" in error_str or "unauthorized" in error_str:
+            return (
+                "🔑 **Authentication Error**\n\n"
+                "There's an issue with your API credentials:\n"
+                "• API key may be invalid or expired\n"
+                "• API key may not have required permissions\n\n"
+                "**What to try:**\n"
+                "• Check your API key configuration\n"
+                "• Verify your API key is still valid\n"
+                "• Check if your API key has required permissions"
+            )
+        
+        else:
+            return (
+                "🌐 **API Error**\n\n"
+                f"An error occurred while communicating with the AI service:\n"
+                f"`{str(error)}`\n\n"
+                "**What to try:**\n"
+                "• Click 'Retry' to try again\n"
+                "• Check your internet connection\n"
+                "• Verify your API configuration"
+            )
+    
+    @staticmethod
+    def _format_content_error(error: Exception) -> str:
+        """Format content-related errors."""
+        return (
+            "📄 **Content Error**\n\n"
+            f"There's an issue with the content you provided:\n"
+            f"`{str(error)}`\n\n"
+            "**What to try:**\n"
+            "• Make sure your content is not empty\n"
+            "• Check that the content is readable text\n"
+            "• Try with different content\n"
+            "• If using a file, make sure it's not corrupted"
+        )
+    
+    @staticmethod
+    def _format_config_error(error: Exception) -> str:
+        """Format configuration-related errors."""
+        return (
+            "⚙️ **Configuration Error**\n\n"
+            f"There's an issue with your configuration:\n"
+            f"`{str(error)}`\n\n"
+            "**What to try:**\n"
+            "• Check your speaker and episode profiles\n"
+            "• Verify all required fields are filled\n"
+            "• Try with a different profile\n"
+            "• Check your model settings"
+        )
+    
+    @staticmethod
+    def _format_generic_error(error: Exception) -> str:
+        """Format generic errors."""
+        return (
+            "❌ **Unexpected Error**\n\n"
+            f"An unexpected error occurred:\n"
+            f"`{str(error)}`\n\n"
+            "**What to try:**\n"
+            "• Click 'Retry' to try again\n"
+            "• Try with different settings\n"
+            "• Check your configuration\n"
+            "• If the problem persists, try restarting the application"
+        )
+    
+    @staticmethod
+    def display_error_message(error_msg: str, error_type: ErrorType = ErrorType.UNKNOWN_ERROR) -> None:
+        """
+        Display a formatted error message in Streamlit.
+        
+        Args:
+            error_msg: The error message to display
+            error_type: Type of error for appropriate styling
+        """
+        if error_type == ErrorType.NETWORK_ERROR:
+            st.error(error_msg)
+        elif error_type == ErrorType.VALIDATION_ERROR:
+            st.warning(error_msg)
+        else:
+            st.error(error_msg)
+    
+    @staticmethod
+    def get_retry_options(error_type: ErrorType) -> List[str]:
+        """
+        Get appropriate retry options based on error type.
+        
+        Args:
+            error_type: Type of error that occurred
+            
+        Returns:
+            List of retry option descriptions
+        """
+        if error_type == ErrorType.NETWORK_ERROR:
+            return [
+                "Retry with same settings",
+                "Check network connection",
+                "Try with different API endpoint"
+            ]
+        elif error_type == ErrorType.CONTENT_ERROR:
+            return [
+                "Try with different content",
+                "Check content format",
+                "Use shorter content"
+            ]
+        elif error_type == ErrorType.PROFILE_ERROR:
+            return [
+                "Try with different profile",
+                "Check profile configuration",
+                "Create new profile"
+            ]
+        elif error_type == ErrorType.GENERATION_ERROR:
+            return [
+                "Retry generation",
+                "Try with different settings",
+                "Use different AI model"
+            ]
+        else:
+            return [
+                "Retry operation",
+                "Check configuration",
+                "Try different settings"
+            ]
+    
+    @staticmethod
+    def classify_error(error: Exception) -> ErrorType:
+        """
+        Classify an error into an appropriate error type.
+        
+        Args:
+            error: The exception to classify
+            
+        Returns:
+            Appropriate ErrorType
+        """
+        error_str = str(error).lower()
+        
+        # Network/API errors
+        if any(keyword in error_str for keyword in ["timeout", "connection", "network", "api", "http"]):
+            return ErrorType.NETWORK_ERROR
+        
+        # File errors
+        if any(keyword in error_str for keyword in ["file", "path", "directory", "permission"]):
+            return ErrorType.FILE_ERROR
+        
+        # Content errors
+        if any(keyword in error_str for keyword in ["content", "empty", "invalid", "format"]):
+            return ErrorType.CONTENT_ERROR
+        
+        # Profile errors
+        if any(keyword in error_str for keyword in ["profile", "config", "speaker", "episode"]):
+            return ErrorType.PROFILE_ERROR
+        
+        # Generation errors
+        if any(keyword in error_str for keyword in ["generation", "create", "podcast", "outline", "transcript"]):
+            return ErrorType.GENERATION_ERROR
+        
+        # Validation errors
+        if any(keyword in error_str for keyword in ["validation", "validate", "required", "missing"]):
+            return ErrorType.VALIDATION_ERROR
+        
+        # Import errors
+        if any(keyword in error_str for keyword in ["import", "module", "dependency"]):
+            return ErrorType.IMPORT_ERROR
+        
+        return ErrorType.UNKNOWN_ERROR
+    
+    @staticmethod
+    def create_error_report(error: Exception, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """
+        Create a detailed error report for debugging.
+        
+        Args:
+            error: The exception that occurred
+            context: Additional context information
+            
+        Returns:
+            Dictionary containing error details
+        """
+        error_report = {
+            "error_type": str(type(error).__name__),
+            "error_message": str(error),
+            "error_classification": ErrorHandler.classify_error(error).value,
+            "traceback": traceback.format_exc(),
+            "context": context or {}
+        }
+        
+        return error_report
+    
+    @staticmethod
+    def log_error(error: Exception, context: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Log an error for debugging purposes.
+        
+        Args:
+            error: The exception that occurred
+            context: Additional context information
+        """
+        error_report = ErrorHandler.create_error_report(error, context)
+        
+        # In a real application, you might want to log to a file or external service
+        # For now, we'll just print to console
+        print(f"Error logged: {error_report}")
+    
+    @staticmethod
+    def handle_streamlit_error(error: Exception, context: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Handle an error in Streamlit with appropriate UI feedback.
+        
+        Args:
+            error: The exception that occurred
+            context: Additional context information
+        """
+        # Classify the error
+        error_type = ErrorHandler.classify_error(error)
+        
+        # Generate user-friendly message
+        if error_type == ErrorType.GENERATION_ERROR:
+            user_message = ErrorHandler.handle_generation_error(error)
+        else:
+            user_message = ErrorHandler._format_generic_error(error)
+        
+        # Display the error
+        ErrorHandler.display_error_message(user_message, error_type)
+        
+        # Log the error for debugging
+        ErrorHandler.log_error(error, context)
+        
+        # Show retry options
+        retry_options = ErrorHandler.get_retry_options(error_type)
+        if retry_options:
+            st.markdown("### Suggested Actions:")
+            for option in retry_options:
+                st.markdown(f"• {option}")
+    
+    @staticmethod
+    def create_error_expander(error: Exception, context: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Create an expandable error details section.
+        
+        Args:
+            error: The exception that occurred
+            context: Additional context information
+        """
+        with st.expander("🔍 Error Details (for debugging)"):
+            error_report = ErrorHandler.create_error_report(error, context)
+            
+            st.markdown("**Error Type:** " + error_report["error_type"])
+            st.markdown("**Error Message:** " + error_report["error_message"])
+            st.markdown("**Classification:** " + error_report["error_classification"])
+            
+            if error_report["context"]:
+                st.markdown("**Context:**")
+                st.json(error_report["context"])
+            
+            st.markdown("**Traceback:**")
+            st.code(error_report["traceback"], language="python")

--- a/src/podcast_creator/resources/streamlit_app/utils/profile_manager.py
+++ b/src/podcast_creator/resources/streamlit_app/utils/profile_manager.py
@@ -1,0 +1,442 @@
+"""
+Profile management utilities for the Podcast Creator Studio.
+
+Handles CRUD operations for speaker and episode profiles.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Any, Union
+import streamlit as st
+from copy import deepcopy
+
+try:
+    from podcast_creator import load_speaker_config, load_episode_config, configure
+    PODCAST_CREATOR_AVAILABLE = True
+except ImportError:
+    PODCAST_CREATOR_AVAILABLE = False
+
+
+class ProfileManager:
+    """Manages speaker and episode profiles including CRUD operations."""
+    
+    def __init__(self, working_dir: str = "."):
+        """
+        Initialize the profile manager.
+        
+        Args:
+            working_dir: Working directory for profile files
+        """
+        self.working_dir = Path(working_dir)
+        self.speakers_config_path = self.working_dir / "speakers_config.json"
+        self.episodes_config_path = self.working_dir / "episodes_config.json"
+        
+        # Initialize config files if they don't exist
+        self._ensure_config_files()
+    
+    def _ensure_config_files(self):
+        """Ensure configuration files exist with default structure."""
+        
+        # Default speaker config structure
+        default_speakers = {
+            "profiles": {
+                "ai_researchers": {
+                    "tts_provider": "elevenlabs",
+                    "tts_model": "eleven_flash_v2_5",
+                    "speakers": [
+                        {
+                            "name": "Dr. Alex Chen",
+                            "voice_id": "voice_id_1",
+                            "backstory": "Senior AI researcher with focus on machine learning ethics",
+                            "personality": "Thoughtful, asks probing questions, explains complex concepts clearly"
+                        },
+                        {
+                            "name": "Jamie Rodriguez",
+                            "voice_id": "voice_id_2", 
+                            "backstory": "Tech journalist and startup advisor with 10 years experience",
+                            "personality": "Enthusiastic, great at explanations, bridges technical and business perspectives"
+                        }
+                    ]
+                },
+                "solo_expert": {
+                    "tts_provider": "elevenlabs",
+                    "tts_model": "eleven_flash_v2_5",
+                    "speakers": [
+                        {
+                            "name": "Dr. Sarah Mitchell",
+                            "voice_id": "voice_id_3",
+                            "backstory": "Expert educator and researcher with ability to explain complex topics",
+                            "personality": "Clear, authoritative, engaging, uses analogies and examples"
+                        }
+                    ]
+                }
+            }
+        }
+        
+        # Default episode config structure
+        default_episodes = {
+            "profiles": {
+                "tech_discussion": {
+                    "speaker_config": "ai_researchers",
+                    "outline_model": "gpt-4o",
+                    "transcript_model": "gpt-4o",
+                    "num_segments": 4,
+                    "default_briefing": "Create an engaging technical discussion that explores the topic in depth"
+                },
+                "solo_expert": {
+                    "speaker_config": "solo_expert",
+                    "outline_model": "gpt-4o", 
+                    "transcript_model": "gpt-4o",
+                    "num_segments": 3,
+                    "default_briefing": "Create an educational explanation that breaks down complex concepts"
+                }
+            }
+        }
+        
+        # Create speakers config if it doesn't exist
+        if not self.speakers_config_path.exists():
+            self._save_json(self.speakers_config_path, default_speakers)
+        
+        # Create episodes config if it doesn't exist
+        if not self.episodes_config_path.exists():
+            self._save_json(self.episodes_config_path, default_episodes)
+    
+    def _load_json(self, file_path: Path) -> Dict[str, Any]:
+        """Load JSON data from file."""
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception as e:
+            st.error(f"Error loading {file_path}: {e}")
+            return {}
+    
+    def _save_json(self, file_path: Path, data: Dict[str, Any]) -> bool:
+        """Save JSON data to file."""
+        try:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+            return True
+        except Exception as e:
+            st.error(f"Error saving {file_path}: {e}")
+            return False
+    
+    # Speaker Profile Management
+    
+    def load_speaker_profiles(self) -> Dict[str, Any]:
+        """Load all speaker profiles."""
+        return self._load_json(self.speakers_config_path)
+    
+    def get_speaker_profile(self, profile_name: str) -> Optional[Dict[str, Any]]:
+        """Get a specific speaker profile."""
+        profiles = self.load_speaker_profiles()
+        return profiles.get("profiles", {}).get(profile_name)
+    
+    def create_speaker_profile(self, profile_name: str, profile_data: Dict[str, Any]) -> bool:
+        """Create a new speaker profile."""
+        profiles = self.load_speaker_profiles()
+        
+        if profile_name in profiles.get("profiles", {}):
+            st.error(f"Speaker profile '{profile_name}' already exists")
+            return False
+        
+        profiles.setdefault("profiles", {})[profile_name] = profile_data
+        return self._save_json(self.speakers_config_path, profiles)
+    
+    def update_speaker_profile(self, profile_name: str, profile_data: Dict[str, Any]) -> bool:
+        """Update an existing speaker profile."""
+        profiles = self.load_speaker_profiles()
+        
+        if profile_name not in profiles.get("profiles", {}):
+            st.error(f"Speaker profile '{profile_name}' not found")
+            return False
+        
+        profiles["profiles"][profile_name] = profile_data
+        return self._save_json(self.speakers_config_path, profiles)
+    
+    def delete_speaker_profile(self, profile_name: str) -> bool:
+        """Delete a speaker profile."""
+        profiles = self.load_speaker_profiles()
+        
+        if profile_name not in profiles.get("profiles", {}):
+            st.error(f"Speaker profile '{profile_name}' not found")
+            return False
+        
+        del profiles["profiles"][profile_name]
+        return self._save_json(self.speakers_config_path, profiles)
+    
+    def clone_speaker_profile(self, source_name: str, new_name: str) -> bool:
+        """Clone a speaker profile with a new name."""
+        source_profile = self.get_speaker_profile(source_name)
+        
+        if not source_profile:
+            st.error(f"Source speaker profile '{source_name}' not found")
+            return False
+        
+        cloned_profile = deepcopy(source_profile)
+        return self.create_speaker_profile(new_name, cloned_profile)
+    
+    def get_speaker_profile_names(self) -> List[str]:
+        """Get list of all speaker profile names."""
+        profiles = self.load_speaker_profiles()
+        return list(profiles.get("profiles", {}).keys())
+    
+    # Episode Profile Management
+    
+    def load_episode_profiles(self) -> Dict[str, Any]:
+        """Load all episode profiles."""
+        return self._load_json(self.episodes_config_path)
+    
+    def get_episode_profile(self, profile_name: str) -> Optional[Dict[str, Any]]:
+        """Get a specific episode profile."""
+        profiles = self.load_episode_profiles()
+        return profiles.get("profiles", {}).get(profile_name)
+    
+    def create_episode_profile(self, profile_name: str, profile_data: Dict[str, Any]) -> bool:
+        """Create a new episode profile."""
+        profiles = self.load_episode_profiles()
+        
+        if profile_name in profiles.get("profiles", {}):
+            st.error(f"Episode profile '{profile_name}' already exists")
+            return False
+        
+        profiles.setdefault("profiles", {})[profile_name] = profile_data
+        return self._save_json(self.episodes_config_path, profiles)
+    
+    def update_episode_profile(self, profile_name: str, profile_data: Dict[str, Any]) -> bool:
+        """Update an existing episode profile."""
+        profiles = self.load_episode_profiles()
+        
+        if profile_name not in profiles.get("profiles", {}):
+            st.error(f"Episode profile '{profile_name}' not found")
+            return False
+        
+        profiles["profiles"][profile_name] = profile_data
+        return self._save_json(self.episodes_config_path, profiles)
+    
+    def delete_episode_profile(self, profile_name: str) -> bool:
+        """Delete an episode profile."""
+        profiles = self.load_episode_profiles()
+        
+        if profile_name not in profiles.get("profiles", {}):
+            st.error(f"Episode profile '{profile_name}' not found")
+            return False
+        
+        del profiles["profiles"][profile_name]
+        return self._save_json(self.episodes_config_path, profiles)
+    
+    def clone_episode_profile(self, source_name: str, new_name: str) -> bool:
+        """Clone an episode profile with a new name."""
+        source_profile = self.get_episode_profile(source_name)
+        
+        if not source_profile:
+            st.error(f"Source episode profile '{source_name}' not found")
+            return False
+        
+        cloned_profile = deepcopy(source_profile)
+        return self.create_episode_profile(new_name, cloned_profile)
+    
+    def get_episode_profile_names(self) -> List[str]:
+        """Get list of all episode profile names."""
+        profiles = self.load_episode_profiles()
+        return list(profiles.get("profiles", {}).keys())
+    
+    # Import/Export Functions
+    
+    def export_speaker_profiles(self, profile_names: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Export speaker profiles to a dictionary."""
+        all_profiles = self.load_speaker_profiles()
+        
+        if profile_names is None:
+            return all_profiles
+        
+        # Export only specified profiles
+        exported = {"profiles": {}}
+        for name in profile_names:
+            if name in all_profiles.get("profiles", {}):
+                exported["profiles"][name] = all_profiles["profiles"][name]
+        
+        return exported
+    
+    def export_episode_profiles(self, profile_names: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Export episode profiles to a dictionary."""
+        all_profiles = self.load_episode_profiles()
+        
+        if profile_names is None:
+            return all_profiles
+        
+        # Export only specified profiles
+        exported = {"profiles": {}}
+        for name in profile_names:
+            if name in all_profiles.get("profiles", {}):
+                exported["profiles"][name] = all_profiles["profiles"][name]
+        
+        return exported
+    
+    def import_speaker_profiles(self, file_content: str) -> List[str]:
+        """
+        Import speaker profiles from JSON content.
+        
+        Args:
+            file_content: JSON content as string
+            
+        Returns:
+            List of imported profile names
+        """
+        try:
+            import_data = json.loads(file_content)
+            imported_names = []
+            
+            if "profiles" in import_data:
+                current_profiles = self.load_speaker_profiles()
+                
+                for profile_name, profile_data in import_data["profiles"].items():
+                    # Check if profile already exists
+                    if profile_name in current_profiles.get("profiles", {}):
+                        st.warning(f"Speaker profile '{profile_name}' already exists, skipping")
+                        continue
+                    
+                    if self.create_speaker_profile(profile_name, profile_data):
+                        imported_names.append(profile_name)
+                
+                return imported_names
+            else:
+                st.error("Invalid format: 'profiles' key not found")
+                return []
+                
+        except json.JSONDecodeError as e:
+            st.error(f"Invalid JSON format: {e}")
+            return []
+        except Exception as e:
+            st.error(f"Error importing profiles: {e}")
+            return []
+    
+    def import_episode_profiles(self, file_content: str) -> List[str]:
+        """
+        Import episode profiles from JSON content.
+        
+        Args:
+            file_content: JSON content as string
+            
+        Returns:
+            List of imported profile names
+        """
+        try:
+            import_data = json.loads(file_content)
+            imported_names = []
+            
+            if "profiles" in import_data:
+                current_profiles = self.load_episode_profiles()
+                
+                for profile_name, profile_data in import_data["profiles"].items():
+                    # Check if profile already exists
+                    if profile_name in current_profiles.get("profiles", {}):
+                        st.warning(f"Episode profile '{profile_name}' already exists, skipping")
+                        continue
+                    
+                    if self.create_episode_profile(profile_name, profile_data):
+                        imported_names.append(profile_name)
+                
+                return imported_names
+            else:
+                st.error("Invalid format: 'profiles' key not found")
+                return []
+                
+        except json.JSONDecodeError as e:
+            st.error(f"Invalid JSON format: {e}")
+            return []
+        except Exception as e:
+            st.error(f"Error importing profiles: {e}")
+            return []
+    
+    # Validation Functions
+    
+    def validate_speaker_profile(self, profile_data: Dict[str, Any]) -> List[str]:
+        """
+        Validate speaker profile data.
+        
+        Args:
+            profile_data: Profile data to validate
+            
+        Returns:
+            List of validation errors (empty if valid)
+        """
+        errors = []
+        
+        # Check required fields
+        if "tts_provider" not in profile_data:
+            errors.append("TTS provider is required")
+        
+        if "tts_model" not in profile_data:
+            errors.append("TTS model is required")
+        
+        if "speakers" not in profile_data:
+            errors.append("Speakers list is required")
+        elif not isinstance(profile_data["speakers"], list):
+            errors.append("Speakers must be a list")
+        elif len(profile_data["speakers"]) == 0:
+            errors.append("At least one speaker is required")
+        else:
+            # Validate each speaker
+            for i, speaker in enumerate(profile_data["speakers"]):
+                if not isinstance(speaker, dict):
+                    errors.append(f"Speaker {i+1} must be an object")
+                    continue
+                
+                required_fields = ["name", "voice_id", "backstory", "personality"]
+                for field in required_fields:
+                    if field not in speaker:
+                        errors.append(f"Speaker {i+1} missing required field: {field}")
+        
+        return errors
+    
+    def validate_episode_profile(self, profile_data: Dict[str, Any]) -> List[str]:
+        """
+        Validate episode profile data.
+        
+        Args:
+            profile_data: Profile data to validate
+            
+        Returns:
+            List of validation errors (empty if valid)
+        """
+        errors = []
+        
+        # Check required fields
+        required_fields = ["speaker_config", "outline_model", "transcript_model", "num_segments"]
+        for field in required_fields:
+            if field not in profile_data:
+                errors.append(f"Required field missing: {field}")
+        
+        # Validate num_segments
+        if "num_segments" in profile_data:
+            try:
+                num_segments = int(profile_data["num_segments"])
+                if num_segments < 1 or num_segments > 10:
+                    errors.append("Number of segments must be between 1 and 10")
+            except (ValueError, TypeError):
+                errors.append("Number of segments must be a valid integer")
+        
+        # Validate speaker_config exists
+        if "speaker_config" in profile_data:
+            speaker_names = self.get_speaker_profile_names()
+            if profile_data["speaker_config"] not in speaker_names:
+                errors.append(f"Speaker config '{profile_data['speaker_config']}' not found")
+        
+        return errors
+    
+    # Statistics and Info
+    
+    def get_profiles_stats(self) -> Dict[str, Any]:
+        """Get statistics about profiles."""
+        speaker_profiles = self.load_speaker_profiles()
+        episode_profiles = self.load_episode_profiles()
+        
+        return {
+            "speaker_profiles_count": len(speaker_profiles.get("profiles", {})),
+            "episode_profiles_count": len(episode_profiles.get("profiles", {})),
+            "total_speakers": sum(
+                len(profile.get("speakers", [])) 
+                for profile in speaker_profiles.get("profiles", {}).values()
+            )
+        }

--- a/src/podcast_creator/resources/streamlit_app/utils/provider_checker.py
+++ b/src/podcast_creator/resources/streamlit_app/utils/provider_checker.py
@@ -1,0 +1,313 @@
+"""
+Provider availability checker for the Podcast Creator Studio.
+
+Checks which AI and TTS providers are available based on environment variables.
+"""
+
+import os
+import streamlit as st
+from typing import Dict, List, Tuple
+
+
+class ProviderChecker:
+    """Utility class for checking provider availability based on environment variables."""
+    
+    @staticmethod
+    def check_available_providers() -> Tuple[List[str], List[str]]:
+        """
+        Check which providers are available based on environment variables.
+        
+        Returns:
+            Tuple of (available_providers, unavailable_providers)
+        """
+        provider_status = {}
+        
+        # AI/LLM Providers
+        provider_status["ollama"] = os.environ.get("OLLAMA_API_BASE") is not None
+        provider_status["openai"] = os.environ.get("OPENAI_API_KEY") is not None
+        provider_status["groq"] = os.environ.get("GROQ_API_KEY") is not None
+        provider_status["xai"] = os.environ.get("XAI_API_KEY") is not None
+        provider_status["vertexai"] = (
+            os.environ.get("VERTEX_PROJECT") is not None
+            and os.environ.get("VERTEX_LOCATION") is not None
+            and os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") is not None
+        )
+        provider_status["gemini"] = (
+            os.environ.get("GOOGLE_API_KEY") is not None
+            or os.environ.get("GEMINI_API_KEY") is not None
+        )
+        provider_status["openrouter"] = (
+            os.environ.get("OPENROUTER_API_KEY") is not None
+            and os.environ.get("OPENAI_API_KEY") is not None
+            and os.environ.get("OPENROUTER_BASE_URL") is not None
+        )
+        provider_status["anthropic"] = os.environ.get("ANTHROPIC_API_KEY") is not None
+        provider_status["azure"] = (
+            os.environ.get("AZURE_OPENAI_API_KEY") is not None
+            and os.environ.get("AZURE_OPENAI_ENDPOINT") is not None
+            and os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME") is not None
+            and os.environ.get("AZURE_OPENAI_API_VERSION") is not None
+        )
+        provider_status["mistral"] = os.environ.get("MISTRAL_API_KEY") is not None
+        provider_status["deepseek"] = os.environ.get("DEEPSEEK_API_KEY") is not None
+        
+        # TTS Providers
+        provider_status["elevenlabs"] = os.environ.get("ELEVENLABS_API_KEY") is not None
+        # Note: openai and google are already checked above for LLM, they also do TTS
+        
+        available_providers = [k for k, v in provider_status.items() if v]
+        unavailable_providers = [k for k, v in provider_status.items() if not v]
+        
+        return available_providers, unavailable_providers
+    
+    @staticmethod
+    def get_available_llm_providers() -> List[str]:
+        """
+        Get list of available LLM providers.
+        
+        Returns:
+            List of available LLM provider names
+        """
+        available_providers, _ = ProviderChecker.check_available_providers()
+        
+        # Filter to only LLM providers (exclude TTS-only providers)
+        llm_providers = [
+            "ollama", "openai", "groq", "xai", "vertexai", "gemini", 
+            "openrouter", "anthropic", "azure", "mistral", "deepseek"
+        ]
+        
+        return [p for p in llm_providers if p in available_providers]
+    
+    @staticmethod
+    def get_available_tts_providers() -> List[str]:
+        """
+        Get list of available TTS providers.
+        
+        Returns:
+            List of available TTS provider names
+        """
+        available_providers, _ = ProviderChecker.check_available_providers()
+        
+        # TTS providers
+        tts_providers = ["elevenlabs", "openai", "google"]
+        
+        return [p for p in tts_providers if p in available_providers]
+    
+    @staticmethod
+    def get_default_models(provider: str) -> Dict[str, str]:
+        """
+        Get default models for a provider.
+        
+        Args:
+            provider: Provider name
+            
+        Returns:
+            Dictionary with default models
+        """
+        defaults = {
+            "openai": {
+                "outline": "gpt-4o",
+                "transcript": "gpt-4o",
+                "tts": "tts-1"
+            },
+            "anthropic": {
+                "outline": "claude-3-5-sonnet-20241022",
+                "transcript": "claude-3-5-sonnet-20241022"
+            },
+            "gemini": {
+                "outline": "gemini-1.5-pro",
+                "transcript": "gemini-1.5-pro"
+            },
+            "google": {
+                "outline": "gemini-1.5-pro",
+                "transcript": "gemini-1.5-pro",
+                "tts": "standard"
+            },
+            "groq": {
+                "outline": "llama-3.1-70b-versatile",
+                "transcript": "llama-3.1-70b-versatile"
+            },
+            "ollama": {
+                "outline": "llama3.1",
+                "transcript": "llama3.1"
+            },
+            "openrouter": {
+                "outline": "meta-llama/llama-3.1-70b-instruct",
+                "transcript": "meta-llama/llama-3.1-70b-instruct"
+            },
+            "azure": {
+                "outline": "gpt-4o",
+                "transcript": "gpt-4o"
+            },
+            "mistral": {
+                "outline": "mistral-large-latest",
+                "transcript": "mistral-large-latest"
+            },
+            "deepseek": {
+                "outline": "deepseek-chat",
+                "transcript": "deepseek-chat"
+            },
+            "xai": {
+                "outline": "grok-beta",
+                "transcript": "grok-beta"
+            },
+            "elevenlabs": {
+                "tts": "eleven_flash_v2_5"
+            }
+        }
+        
+        return defaults.get(provider, {})
+    
+    @staticmethod
+    def render_provider_selector(
+        label: str,
+        providers: List[str],
+        current_provider: str = "",
+        key: str = "",
+        help_text: str = ""
+    ) -> str:
+        """
+        Render a provider selector with only available providers.
+        
+        Args:
+            label: Label for the selectbox
+            providers: List of all possible providers
+            current_provider: Currently selected provider
+            key: Unique key for the widget
+            help_text: Help text for the widget
+            
+        Returns:
+            Selected provider
+        """
+        available_providers = ProviderChecker.get_available_llm_providers()
+        
+        # Filter providers to only available ones
+        filtered_providers = [p for p in providers if p in available_providers]
+        
+        if not filtered_providers:
+            st.error("❌ No AI providers available. Please configure API keys.")
+            return current_provider or ""
+        
+        # Find current selection index
+        current_index = 0
+        if current_provider and current_provider in filtered_providers:
+            current_index = filtered_providers.index(current_provider)
+        elif current_provider not in filtered_providers and filtered_providers:
+            # Current provider not available, add it as disabled option
+            filtered_providers.insert(0, f"{current_provider} (unavailable)")
+            current_index = 0
+        
+        # Show warning about unavailable providers
+        unavailable_count = len(providers) - len(filtered_providers)
+        if unavailable_count > 0:
+            st.info(f"ℹ️ {unavailable_count} providers unavailable due to missing API keys")
+        
+        selected = st.selectbox(
+            label,
+            filtered_providers,
+            index=current_index,
+            key=key,
+            help=help_text
+        )
+        
+        # Clean up the selection if it was marked as unavailable
+        if selected and "(unavailable)" in selected:
+            return selected.replace(" (unavailable)", "")
+        
+        return selected
+    
+    @staticmethod
+    def render_tts_provider_selector(
+        label: str,
+        current_provider: str = "",
+        key: str = "",
+        help_text: str = ""
+    ) -> str:
+        """
+        Render a TTS provider selector with only available providers.
+        
+        Args:
+            label: Label for the selectbox
+            current_provider: Currently selected provider
+            key: Unique key for the widget
+            help_text: Help text for the widget
+            
+        Returns:
+            Selected provider
+        """
+        available_providers = ProviderChecker.get_available_tts_providers()
+        
+        if not available_providers:
+            st.error("❌ No TTS providers available. Please configure API keys.")
+            return current_provider or ""
+        
+        # Find current selection index
+        current_index = 0
+        if current_provider and current_provider in available_providers:
+            current_index = available_providers.index(current_provider)
+        elif current_provider not in available_providers and available_providers:
+            # Current provider not available, add it as disabled option
+            available_providers.insert(0, f"{current_provider} (unavailable)")
+            current_index = 0
+        
+        selected = st.selectbox(
+            label,
+            available_providers,
+            index=current_index,
+            key=key,
+            help=help_text
+        )
+        
+        # Clean up the selection if it was marked as unavailable
+        if selected and "(unavailable)" in selected:
+            return selected.replace(" (unavailable)", "")
+        
+        return selected
+    
+    @staticmethod
+    def show_provider_status():
+        """Show provider availability status in the UI."""
+        available_providers, unavailable_providers = ProviderChecker.check_available_providers()
+        
+        st.markdown("### 🔌 Provider Status")
+        
+        col1, col2 = st.columns(2)
+        
+        with col1:
+            st.markdown("**✅ Available:**")
+            if available_providers:
+                for provider in sorted(available_providers):
+                    st.markdown(f"- {provider}")
+            else:
+                st.markdown("*No providers configured*")
+        
+        with col2:
+            st.markdown("**❌ Unavailable:**")
+            if unavailable_providers:
+                for provider in sorted(unavailable_providers):
+                    st.markdown(f"- {provider}")
+            else:
+                st.markdown("*All providers configured*")
+        
+        if unavailable_providers:
+            with st.expander("🔧 Configuration Help"):
+                st.markdown("**To enable providers, set these environment variables:**")
+                
+                config_help = {
+                    "openai": "OPENAI_API_KEY",
+                    "anthropic": "ANTHROPIC_API_KEY", 
+                    "groq": "GROQ_API_KEY",
+                    "xai": "XAI_API_KEY",
+                    "mistral": "MISTRAL_API_KEY",
+                    "deepseek": "DEEPSEEK_API_KEY",
+                    "elevenlabs": "ELEVENLABS_API_KEY",
+                    "gemini": "GOOGLE_API_KEY or GEMINI_API_KEY",
+                    "vertexai": "VERTEX_PROJECT, VERTEX_LOCATION, GOOGLE_APPLICATION_CREDENTIALS",
+                    "azure": "AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT_NAME, AZURE_OPENAI_API_VERSION",
+                    "openrouter": "OPENROUTER_API_KEY, OPENAI_API_KEY, OPENROUTER_BASE_URL",
+                    "ollama": "OLLAMA_API_BASE"
+                }
+                
+                for provider in sorted(unavailable_providers):
+                    if provider in config_help:
+                        st.markdown(f"**{provider}:** `{config_help[provider]}`")

--- a/src/podcast_creator/resources/streamlit_app/utils/voice_provider.py
+++ b/src/podcast_creator/resources/streamlit_app/utils/voice_provider.py
@@ -1,0 +1,259 @@
+"""
+Voice provider utilities for the Podcast Creator Studio.
+
+Handles voice selection for different TTS providers.
+"""
+
+import streamlit as st
+from typing import Dict, List, Tuple, Optional
+import requests
+import json
+
+try:
+    from esperanto import AIFactory
+    ESPERANTO_AVAILABLE = True
+except ImportError:
+    ESPERANTO_AVAILABLE = False
+
+
+class VoiceProvider:
+    """Voice provider utility for getting available voices from TTS providers."""
+    
+    @staticmethod
+    def is_esperanto_available() -> bool:
+        """Check if esperanto library is available."""
+        return ESPERANTO_AVAILABLE
+    
+    @staticmethod
+    def get_available_voices(provider: str, model: str = None) -> Dict[str, str]:
+        """
+        Get available voices for a TTS provider.
+        
+        Args:
+            provider: TTS provider name (elevenlabs, openai, google)
+            model: Optional model name for the provider
+            
+        Returns:
+            Dictionary mapping voice names to voice IDs
+        """
+        if not ESPERANTO_AVAILABLE:
+            return {}
+        
+        try:
+            # Create TTS instance based on provider
+            if provider == "elevenlabs":
+                model = model or "eleven_flash_v2_5"
+                tts = AIFactory.create_text_to_speech(provider, model)
+            elif provider == "openai":
+                model = model or "tts-1"
+                tts = AIFactory.create_text_to_speech(provider, model)
+            elif provider == "google":
+                model = model or "standard"
+                tts = AIFactory.create_text_to_speech(provider, model)
+            else:
+                return {}
+            
+            # Get available voices
+            voices = tts.available_voices
+            
+            # Process voices based on provider
+            if provider == "elevenlabs":
+                # ElevenLabs returns a dict with voice objects
+                return {
+                    f"{voice.name} ({voice.gender}, {voice.description[:50]}...)": voice.id
+                    for voice in voices.values()
+                }
+            elif provider == "openai":
+                # OpenAI has predefined voices
+                return {
+                    "Alloy": "alloy",
+                    "Echo": "echo", 
+                    "Fable": "fable",
+                    "Onyx": "onyx",
+                    "Nova": "nova",
+                    "Shimmer": "shimmer"
+                }
+            elif provider == "google":
+                # Google has many voices, return a simplified set
+                return {
+                    "Standard A": "en-US-Standard-A",
+                    "Standard B": "en-US-Standard-B",
+                    "Standard C": "en-US-Standard-C",
+                    "Standard D": "en-US-Standard-D",
+                    "Wavenet A": "en-US-Wavenet-A",
+                    "Wavenet B": "en-US-Wavenet-B",
+                    "Wavenet C": "en-US-Wavenet-C",
+                    "Wavenet D": "en-US-Wavenet-D"
+                }
+            else:
+                return {}
+                
+        except Exception as e:
+            st.error(f"Error getting voices for {provider}: {str(e)}")
+            return {}
+    
+    @staticmethod
+    @st.cache_data(ttl=3600)  # Cache for 1 hour
+    def get_cached_voices(provider: str, model: str = None) -> Dict[str, str]:
+        """
+        Get cached available voices for a TTS provider.
+        
+        Args:
+            provider: TTS provider name
+            model: Optional model name
+            
+        Returns:
+            Dictionary mapping voice names to voice IDs
+        """
+        return VoiceProvider.get_available_voices(provider, model)
+    
+    @staticmethod
+    def render_voice_selector(
+        provider: str, 
+        model: str,
+        current_voice_id: str = "",
+        key: str = "voice_selector",
+        help_text: str = "Choose a voice for this speaker"
+    ) -> str:
+        """
+        Render a voice selector widget.
+        
+        Args:
+            provider: TTS provider name
+            model: Model name
+            current_voice_id: Currently selected voice ID
+            key: Unique key for the widget
+            help_text: Help text for the widget
+            
+        Returns:
+            Selected voice ID
+        """
+        if not ESPERANTO_AVAILABLE:
+            st.warning("⚠️ Esperanto library not available. Using text input for voice ID.")
+            return st.text_input(
+                "Voice ID:", 
+                value=current_voice_id,
+                key=key,
+                help="Enter the voice ID manually"
+            )
+        
+        # Get available voices
+        voices = VoiceProvider.get_cached_voices(provider, model)
+        
+        if not voices:
+            st.warning(f"⚠️ No voices available for {provider}. Using text input.")
+            return st.text_input(
+                "Voice ID:", 
+                value=current_voice_id,
+                key=key,
+                help="Enter the voice ID manually"
+            )
+        
+        # Find current selection
+        voice_names = list(voices.keys())
+        voice_ids = list(voices.values())
+        
+        # Try to find current voice in the list
+        current_index = 0
+        if current_voice_id:
+            try:
+                current_index = voice_ids.index(current_voice_id)
+            except ValueError:
+                # Voice not found, add it as an option
+                voice_names.insert(0, f"Current: {current_voice_id}")
+                voice_ids.insert(0, current_voice_id)
+                current_index = 0
+        
+        # Show selectbox
+        selected_name = st.selectbox(
+            "Voice:",
+            voice_names,
+            index=current_index,
+            key=key,
+            help=help_text
+        )
+        
+        # Return the corresponding voice ID
+        selected_index = voice_names.index(selected_name)
+        return voice_ids[selected_index]
+    
+    @staticmethod
+    def get_voice_preview_url(provider: str, voice_id: str) -> Optional[str]:
+        """
+        Get preview URL for a voice if available.
+        
+        Args:
+            provider: TTS provider name
+            voice_id: Voice ID
+            
+        Returns:
+            Preview URL if available, None otherwise
+        """
+        if not ESPERANTO_AVAILABLE or provider != "elevenlabs":
+            return None
+        
+        try:
+            tts = AIFactory.create_text_to_speech(provider, "eleven_flash_v2_5")
+            voices = tts.available_voices
+            
+            for voice in voices.values():
+                if voice.id == voice_id:
+                    return voice.preview_url
+            
+            return None
+        except Exception:
+            return None
+    
+    @staticmethod
+    def render_voice_preview(provider: str, voice_id: str):
+        """
+        Render voice preview if available.
+        
+        Args:
+            provider: TTS provider name
+            voice_id: Voice ID
+        """
+        if provider == "elevenlabs" and voice_id:
+            preview_url = VoiceProvider.get_voice_preview_url(provider, voice_id)
+            if preview_url:
+                st.audio(preview_url, format="audio/mp3")
+    
+    @staticmethod
+    def get_default_voices(provider: str) -> Dict[str, str]:
+        """
+        Get default voices for a provider when API is not available.
+        
+        Args:
+            provider: TTS provider name
+            
+        Returns:
+            Dictionary of default voices
+        """
+        defaults = {
+            "elevenlabs": {
+                "Aria": "9BWtsMINqrJLrRacOk9x",
+                "Sarah": "EXAVITQu4vr4xnSDxMaL",
+                "Laura": "FGY2WhTYpPnrIDTdsKH5",
+                "Charlie": "IKne3meq5aSn9XLyUdCD",
+                "George": "JBFqnCBsd6RMkjVDRZzb",
+                "Brian": "nPczCjzI2devNBz1zQrb",
+                "Daniel": "onwK4e9ZLuTAKqWW03F9",
+                "Lily": "pFZP5JQG7iQjIQuC4Bku"
+            },
+            "openai": {
+                "Alloy": "alloy",
+                "Echo": "echo",
+                "Fable": "fable", 
+                "Onyx": "onyx",
+                "Nova": "nova",
+                "Shimmer": "shimmer"
+            },
+            "google": {
+                "Standard A": "en-US-Standard-A",
+                "Standard B": "en-US-Standard-B",
+                "Standard C": "en-US-Standard-C",
+                "Standard D": "en-US-Standard-D"
+            }
+        }
+        
+        return defaults.get(provider, {})

--- a/src/podcast_creator/state.py
+++ b/src/podcast_creator/state.py
@@ -1,6 +1,6 @@
 from operator import add
 from pathlib import Path
-from typing import Annotated, List, Optional, TypedDict
+from typing import Annotated, List, Optional, TypedDict, Union, Dict
 
 from .core import Dialogue, Outline
 from .speakers import SpeakerProfile
@@ -8,7 +8,7 @@ from .speakers import SpeakerProfile
 
 class PodcastState(TypedDict):
     # Input data
-    content: str
+    content: Union[str, List[Dict]]
     briefing: str
     num_segments: int
 

--- a/src/podcast_creator/validators.py
+++ b/src/podcast_creator/validators.py
@@ -10,7 +10,9 @@ from loguru import logger
 from .speakers import SpeakerConfig
 
 
-def validate_template_syntax(template_content: str, template_name: str = "template") -> bool:
+def validate_template_syntax(
+    template_content: str, template_name: str = "template"
+) -> bool:
     """
     Validate Jinja2 template syntax.
 
@@ -85,7 +87,9 @@ def validate_speaker_config_schema(config: Dict[str, Any]) -> bool:
         raise ValueError(f"Invalid speaker configuration: {e}")
 
 
-def validate_file_path(path: str, must_exist: bool = True, must_be_file: bool = True) -> bool:
+def validate_file_path(
+    path: str, must_exist: bool = True, must_be_file: bool = True
+) -> bool:
     """
     Validate file path.
 
@@ -200,20 +204,20 @@ def validate_voice_ids(speaker_config: Dict[str, Any], provider: str) -> bool:
     """
     try:
         config = SpeakerConfig(**speaker_config)
-        
+
         for profile_name, profile in config.profiles.items():
             if profile.tts_provider.lower() != provider.lower():
                 continue
-                
+
             for speaker in profile.speakers:
                 voice_id = speaker.voice_id
-                
+
                 # Basic validation - voice IDs should not be empty
                 if not voice_id or not voice_id.strip():
                     raise ValueError(
                         f"Empty voice_id for speaker '{speaker.name}' in profile '{profile_name}'"
                     )
-                
+
                 # Provider-specific validation could be added here
                 if provider.lower() == "elevenlabs":
                     # ElevenLabs voice IDs are typically alphanumeric strings
@@ -222,9 +226,9 @@ def validate_voice_ids(speaker_config: Dict[str, Any], provider: str) -> bool:
                             f"Voice ID '{voice_id}' for speaker '{speaker.name}' "
                             f"may not be valid for ElevenLabs"
                         )
-                
+
         return True
-        
+
     except Exception as e:
         raise ValueError(f"Error validating voice IDs: {e}")
 
@@ -247,12 +251,12 @@ def validate_configuration_completeness(config: Dict[str, Any]) -> bool:
     # Check for either templates or prompts_dir
     has_templates = "templates" in config and config["templates"] is not None
     has_prompts_dir = "prompts_dir" in config and config["prompts_dir"] is not None
-    
+
     if not has_templates and not has_prompts_dir:
         # Check if templates exist in current directory
         cwd_outline = Path.cwd() / "prompts" / "podcast" / "outline.jinja"
         cwd_transcript = Path.cwd() / "prompts" / "podcast" / "transcript.jinja"
-        
+
         if not (cwd_outline.exists() and cwd_transcript.exists()):
             issues.append(
                 "No templates configured. Please set 'templates' or 'prompts_dir', "
@@ -261,11 +265,11 @@ def validate_configuration_completeness(config: Dict[str, Any]) -> bool:
 
     # Check for speaker configuration
     has_speakers = "speakers_config" in config and config["speakers_config"] is not None
-    
+
     if not has_speakers:
         # Check if speakers_config.json exists in current directory
         cwd_speakers = Path.cwd() / "speakers_config.json"
-        
+
         if not cwd_speakers.exists():
             issues.append(
                 "No speaker configuration found. Please set 'speakers_config' "

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,10 @@
 version = 1
 requires-python = ">=3.10.6"
+resolution-markers = [
+    "python_full_version < '3.11'",
+    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12'",
+]
 
 [[package]]
 name = "ai-prompter"
@@ -13,6 +18,130 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/88/cadc58aac8bbb599d8c6d25f2cd357e938ddabe3756b1eed68e8860eed22/ai_prompter-0.3.1.tar.gz", hash = "sha256:cec7fddac5edf7d836c13fe77613e16b12b23aea625133846d11ae22455ed397", size = 84837 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/f6/490bf534d6b04755998142ec7412b78e7466dc6d9a3f31e90541506b7971/ai_prompter-0.3.1-py3-none-any.whl", hash = "sha256:ec26566f7f246f511325e1c0f260970963a6e49fb19ed0767152d30b82cd2b79", size = 13386 },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265 },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.12.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/0b/e39ad954107ebf213a2325038a3e7a506be3d98e1435e1f82086eec4cde2/aiohttp-3.12.14.tar.gz", hash = "sha256:6e06e120e34d93100de448fd941522e11dafa78ef1a893c179901b7d66aa29f2", size = 7822921 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/88/f161f429f9de391eee6a5c2cffa54e2ecd5b7122ae99df247f7734dfefcb/aiohttp-3.12.14-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:906d5075b5ba0dd1c66fcaaf60eb09926a9fef3ca92d912d2a0bbdbecf8b1248", size = 702641 },
+    { url = "https://files.pythonhosted.org/packages/fe/b5/24fa382a69a25d242e2baa3e56d5ea5227d1b68784521aaf3a1a8b34c9a4/aiohttp-3.12.14-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c875bf6fc2fd1a572aba0e02ef4e7a63694778c5646cdbda346ee24e630d30fb", size = 479005 },
+    { url = "https://files.pythonhosted.org/packages/09/67/fda1bc34adbfaa950d98d934a23900918f9d63594928c70e55045838c943/aiohttp-3.12.14-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fbb284d15c6a45fab030740049d03c0ecd60edad9cd23b211d7e11d3be8d56fd", size = 466781 },
+    { url = "https://files.pythonhosted.org/packages/36/96/3ce1ea96d3cf6928b87cfb8cdd94650367f5c2f36e686a1f5568f0f13754/aiohttp-3.12.14-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38e360381e02e1a05d36b223ecab7bc4a6e7b5ab15760022dc92589ee1d4238c", size = 1648841 },
+    { url = "https://files.pythonhosted.org/packages/be/04/ddea06cb4bc7d8db3745cf95e2c42f310aad485ca075bd685f0e4f0f6b65/aiohttp-3.12.14-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:aaf90137b5e5d84a53632ad95ebee5c9e3e7468f0aab92ba3f608adcb914fa95", size = 1622896 },
+    { url = "https://files.pythonhosted.org/packages/73/66/63942f104d33ce6ca7871ac6c1e2ebab48b88f78b2b7680c37de60f5e8cd/aiohttp-3.12.14-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e532a25e4a0a2685fa295a31acf65e027fbe2bea7a4b02cdfbbba8a064577663", size = 1695302 },
+    { url = "https://files.pythonhosted.org/packages/20/00/aab615742b953f04b48cb378ee72ada88555b47b860b98c21c458c030a23/aiohttp-3.12.14-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eab9762c4d1b08ae04a6c77474e6136da722e34fdc0e6d6eab5ee93ac29f35d1", size = 1737617 },
+    { url = "https://files.pythonhosted.org/packages/d6/4f/ef6d9f77225cf27747368c37b3d69fac1f8d6f9d3d5de2d410d155639524/aiohttp-3.12.14-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abe53c3812b2899889a7fca763cdfaeee725f5be68ea89905e4275476ffd7e61", size = 1642282 },
+    { url = "https://files.pythonhosted.org/packages/37/e1/e98a43c15aa52e9219a842f18c59cbae8bbe2d50c08d298f17e9e8bafa38/aiohttp-3.12.14-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5760909b7080aa2ec1d320baee90d03b21745573780a072b66ce633eb77a8656", size = 1582406 },
+    { url = "https://files.pythonhosted.org/packages/71/5c/29c6dfb49323bcdb0239bf3fc97ffcf0eaf86d3a60426a3287ec75d67721/aiohttp-3.12.14-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:02fcd3f69051467bbaa7f84d7ec3267478c7df18d68b2e28279116e29d18d4f3", size = 1626255 },
+    { url = "https://files.pythonhosted.org/packages/79/60/ec90782084090c4a6b459790cfd8d17be2c5662c9c4b2d21408b2f2dc36c/aiohttp-3.12.14-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:4dcd1172cd6794884c33e504d3da3c35648b8be9bfa946942d353b939d5f1288", size = 1637041 },
+    { url = "https://files.pythonhosted.org/packages/22/89/205d3ad30865c32bc472ac13f94374210745b05bd0f2856996cb34d53396/aiohttp-3.12.14-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:224d0da41355b942b43ad08101b1b41ce633a654128ee07e36d75133443adcda", size = 1612494 },
+    { url = "https://files.pythonhosted.org/packages/48/ae/2f66edaa8bd6db2a4cba0386881eb92002cdc70834e2a93d1d5607132c7e/aiohttp-3.12.14-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:e387668724f4d734e865c1776d841ed75b300ee61059aca0b05bce67061dcacc", size = 1692081 },
+    { url = "https://files.pythonhosted.org/packages/08/3a/fa73bfc6e21407ea57f7906a816f0dc73663d9549da703be05dbd76d2dc3/aiohttp-3.12.14-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:dec9cde5b5a24171e0b0a4ca064b1414950904053fb77c707efd876a2da525d8", size = 1715318 },
+    { url = "https://files.pythonhosted.org/packages/e3/b3/751124b8ceb0831c17960d06ee31a4732cb4a6a006fdbfa1153d07c52226/aiohttp-3.12.14-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bbad68a2af4877cc103cd94af9160e45676fc6f0c14abb88e6e092b945c2c8e3", size = 1643660 },
+    { url = "https://files.pythonhosted.org/packages/81/3c/72477a1d34edb8ab8ce8013086a41526d48b64f77e381c8908d24e1c18f5/aiohttp-3.12.14-cp310-cp310-win32.whl", hash = "sha256:ee580cb7c00bd857b3039ebca03c4448e84700dc1322f860cf7a500a6f62630c", size = 428289 },
+    { url = "https://files.pythonhosted.org/packages/a2/c4/8aec4ccf1b822ec78e7982bd5cf971113ecce5f773f04039c76a083116fc/aiohttp-3.12.14-cp310-cp310-win_amd64.whl", hash = "sha256:cf4f05b8cea571e2ccc3ca744e35ead24992d90a72ca2cf7ab7a2efbac6716db", size = 451328 },
+    { url = "https://files.pythonhosted.org/packages/53/e1/8029b29316971c5fa89cec170274582619a01b3d82dd1036872acc9bc7e8/aiohttp-3.12.14-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f4552ff7b18bcec18b60a90c6982049cdb9dac1dba48cf00b97934a06ce2e597", size = 709960 },
+    { url = "https://files.pythonhosted.org/packages/96/bd/4f204cf1e282041f7b7e8155f846583b19149e0872752711d0da5e9cc023/aiohttp-3.12.14-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8283f42181ff6ccbcf25acaae4e8ab2ff7e92b3ca4a4ced73b2c12d8cd971393", size = 482235 },
+    { url = "https://files.pythonhosted.org/packages/d6/0f/2a580fcdd113fe2197a3b9df30230c7e85bb10bf56f7915457c60e9addd9/aiohttp-3.12.14-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:040afa180ea514495aaff7ad34ec3d27826eaa5d19812730fe9e529b04bb2179", size = 470501 },
+    { url = "https://files.pythonhosted.org/packages/38/78/2c1089f6adca90c3dd74915bafed6d6d8a87df5e3da74200f6b3a8b8906f/aiohttp-3.12.14-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b413c12f14c1149f0ffd890f4141a7471ba4b41234fe4fd4a0ff82b1dc299dbb", size = 1740696 },
+    { url = "https://files.pythonhosted.org/packages/4a/c8/ce6c7a34d9c589f007cfe064da2d943b3dee5aabc64eaecd21faf927ab11/aiohttp-3.12.14-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d6f607ce2e1a93315414e3d448b831238f1874b9968e1195b06efaa5c87e245", size = 1689365 },
+    { url = "https://files.pythonhosted.org/packages/18/10/431cd3d089de700756a56aa896faf3ea82bee39d22f89db7ddc957580308/aiohttp-3.12.14-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:565e70d03e924333004ed101599902bba09ebb14843c8ea39d657f037115201b", size = 1788157 },
+    { url = "https://files.pythonhosted.org/packages/fa/b2/26f4524184e0f7ba46671c512d4b03022633bcf7d32fa0c6f1ef49d55800/aiohttp-3.12.14-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4699979560728b168d5ab63c668a093c9570af2c7a78ea24ca5212c6cdc2b641", size = 1827203 },
+    { url = "https://files.pythonhosted.org/packages/e0/30/aadcdf71b510a718e3d98a7bfeaea2396ac847f218b7e8edb241b09bd99a/aiohttp-3.12.14-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad5fdf6af93ec6c99bf800eba3af9a43d8bfd66dce920ac905c817ef4a712afe", size = 1729664 },
+    { url = "https://files.pythonhosted.org/packages/67/7f/7ccf11756ae498fdedc3d689a0c36ace8fc82f9d52d3517da24adf6e9a74/aiohttp-3.12.14-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ac76627c0b7ee0e80e871bde0d376a057916cb008a8f3ffc889570a838f5cc7", size = 1666741 },
+    { url = "https://files.pythonhosted.org/packages/6b/4d/35ebc170b1856dd020c92376dbfe4297217625ef4004d56587024dc2289c/aiohttp-3.12.14-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:798204af1180885651b77bf03adc903743a86a39c7392c472891649610844635", size = 1715013 },
+    { url = "https://files.pythonhosted.org/packages/7b/24/46dc0380146f33e2e4aa088b92374b598f5bdcde1718c77e8d1a0094f1a4/aiohttp-3.12.14-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:4f1205f97de92c37dd71cf2d5bcfb65fdaed3c255d246172cce729a8d849b4da", size = 1710172 },
+    { url = "https://files.pythonhosted.org/packages/2f/0a/46599d7d19b64f4d0fe1b57bdf96a9a40b5c125f0ae0d8899bc22e91fdce/aiohttp-3.12.14-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:76ae6f1dd041f85065d9df77c6bc9c9703da9b5c018479d20262acc3df97d419", size = 1690355 },
+    { url = "https://files.pythonhosted.org/packages/08/86/b21b682e33d5ca317ef96bd21294984f72379454e689d7da584df1512a19/aiohttp-3.12.14-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a194ace7bc43ce765338ca2dfb5661489317db216ea7ea700b0332878b392cab", size = 1783958 },
+    { url = "https://files.pythonhosted.org/packages/4f/45/f639482530b1396c365f23c5e3b1ae51c9bc02ba2b2248ca0c855a730059/aiohttp-3.12.14-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:16260e8e03744a6fe3fcb05259eeab8e08342c4c33decf96a9dad9f1187275d0", size = 1804423 },
+    { url = "https://files.pythonhosted.org/packages/7e/e5/39635a9e06eed1d73671bd4079a3caf9cf09a49df08490686f45a710b80e/aiohttp-3.12.14-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c779e5ebbf0e2e15334ea404fcce54009dc069210164a244d2eac8352a44b28", size = 1717479 },
+    { url = "https://files.pythonhosted.org/packages/51/e1/7f1c77515d369b7419c5b501196526dad3e72800946c0099594c1f0c20b4/aiohttp-3.12.14-cp311-cp311-win32.whl", hash = "sha256:a289f50bf1bd5be227376c067927f78079a7bdeccf8daa6a9e65c38bae14324b", size = 427907 },
+    { url = "https://files.pythonhosted.org/packages/06/24/a6bf915c85b7a5b07beba3d42b3282936b51e4578b64a51e8e875643c276/aiohttp-3.12.14-cp311-cp311-win_amd64.whl", hash = "sha256:0b8a69acaf06b17e9c54151a6c956339cf46db4ff72b3ac28516d0f7068f4ced", size = 452334 },
+    { url = "https://files.pythonhosted.org/packages/c3/0d/29026524e9336e33d9767a1e593ae2b24c2b8b09af7c2bd8193762f76b3e/aiohttp-3.12.14-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a0ecbb32fc3e69bc25efcda7d28d38e987d007096cbbeed04f14a6662d0eee22", size = 701055 },
+    { url = "https://files.pythonhosted.org/packages/0a/b8/a5e8e583e6c8c1056f4b012b50a03c77a669c2e9bf012b7cf33d6bc4b141/aiohttp-3.12.14-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0400f0ca9bb3e0b02f6466421f253797f6384e9845820c8b05e976398ac1d81a", size = 475670 },
+    { url = "https://files.pythonhosted.org/packages/29/e8/5202890c9e81a4ec2c2808dd90ffe024952e72c061729e1d49917677952f/aiohttp-3.12.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a56809fed4c8a830b5cae18454b7464e1529dbf66f71c4772e3cfa9cbec0a1ff", size = 468513 },
+    { url = "https://files.pythonhosted.org/packages/23/e5/d11db8c23d8923d3484a27468a40737d50f05b05eebbb6288bafcb467356/aiohttp-3.12.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27f2e373276e4755691a963e5d11756d093e346119f0627c2d6518208483fb6d", size = 1715309 },
+    { url = "https://files.pythonhosted.org/packages/53/44/af6879ca0eff7a16b1b650b7ea4a827301737a350a464239e58aa7c387ef/aiohttp-3.12.14-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ca39e433630e9a16281125ef57ece6817afd1d54c9f1bf32e901f38f16035869", size = 1697961 },
+    { url = "https://files.pythonhosted.org/packages/bb/94/18457f043399e1ec0e59ad8674c0372f925363059c276a45a1459e17f423/aiohttp-3.12.14-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9c748b3f8b14c77720132b2510a7d9907a03c20ba80f469e58d5dfd90c079a1c", size = 1753055 },
+    { url = "https://files.pythonhosted.org/packages/26/d9/1d3744dc588fafb50ff8a6226d58f484a2242b5dd93d8038882f55474d41/aiohttp-3.12.14-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0a568abe1b15ce69d4cc37e23020720423f0728e3cb1f9bcd3f53420ec3bfe7", size = 1799211 },
+    { url = "https://files.pythonhosted.org/packages/73/12/2530fb2b08773f717ab2d249ca7a982ac66e32187c62d49e2c86c9bba9b4/aiohttp-3.12.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9888e60c2c54eaf56704b17feb558c7ed6b7439bca1e07d4818ab878f2083660", size = 1718649 },
+    { url = "https://files.pythonhosted.org/packages/b9/34/8d6015a729f6571341a311061b578e8b8072ea3656b3d72329fa0faa2c7c/aiohttp-3.12.14-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3006a1dc579b9156de01e7916d38c63dc1ea0679b14627a37edf6151bc530088", size = 1634452 },
+    { url = "https://files.pythonhosted.org/packages/ff/4b/08b83ea02595a582447aeb0c1986792d0de35fe7a22fb2125d65091cbaf3/aiohttp-3.12.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aa8ec5c15ab80e5501a26719eb48a55f3c567da45c6ea5bb78c52c036b2655c7", size = 1695511 },
+    { url = "https://files.pythonhosted.org/packages/b5/66/9c7c31037a063eec13ecf1976185c65d1394ded4a5120dd5965e3473cb21/aiohttp-3.12.14-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:39b94e50959aa07844c7fe2206b9f75d63cc3ad1c648aaa755aa257f6f2498a9", size = 1716967 },
+    { url = "https://files.pythonhosted.org/packages/ba/02/84406e0ad1acb0fb61fd617651ab6de760b2d6a31700904bc0b33bd0894d/aiohttp-3.12.14-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:04c11907492f416dad9885d503fbfc5dcb6768d90cad8639a771922d584609d3", size = 1657620 },
+    { url = "https://files.pythonhosted.org/packages/07/53/da018f4013a7a179017b9a274b46b9a12cbeb387570f116964f498a6f211/aiohttp-3.12.14-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:88167bd9ab69bb46cee91bd9761db6dfd45b6e76a0438c7e884c3f8160ff21eb", size = 1737179 },
+    { url = "https://files.pythonhosted.org/packages/49/e8/ca01c5ccfeaafb026d85fa4f43ceb23eb80ea9c1385688db0ef322c751e9/aiohttp-3.12.14-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:791504763f25e8f9f251e4688195e8b455f8820274320204f7eafc467e609425", size = 1765156 },
+    { url = "https://files.pythonhosted.org/packages/22/32/5501ab525a47ba23c20613e568174d6c63aa09e2caa22cded5c6ea8e3ada/aiohttp-3.12.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2785b112346e435dd3a1a67f67713a3fe692d288542f1347ad255683f066d8e0", size = 1724766 },
+    { url = "https://files.pythonhosted.org/packages/06/af/28e24574801fcf1657945347ee10df3892311c2829b41232be6089e461e7/aiohttp-3.12.14-cp312-cp312-win32.whl", hash = "sha256:15f5f4792c9c999a31d8decf444e79fcfd98497bf98e94284bf390a7bb8c1729", size = 422641 },
+    { url = "https://files.pythonhosted.org/packages/98/d5/7ac2464aebd2eecac38dbe96148c9eb487679c512449ba5215d233755582/aiohttp-3.12.14-cp312-cp312-win_amd64.whl", hash = "sha256:3b66e1a182879f579b105a80d5c4bd448b91a57e8933564bf41665064796a338", size = 449316 },
+    { url = "https://files.pythonhosted.org/packages/06/48/e0d2fa8ac778008071e7b79b93ab31ef14ab88804d7ba71b5c964a7c844e/aiohttp-3.12.14-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3143a7893d94dc82bc409f7308bc10d60285a3cd831a68faf1aa0836c5c3c767", size = 695471 },
+    { url = "https://files.pythonhosted.org/packages/8d/e7/f73206afa33100804f790b71092888f47df65fd9a4cd0e6800d7c6826441/aiohttp-3.12.14-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3d62ac3d506cef54b355bd34c2a7c230eb693880001dfcda0bf88b38f5d7af7e", size = 473128 },
+    { url = "https://files.pythonhosted.org/packages/df/e2/4dd00180be551a6e7ee979c20fc7c32727f4889ee3fd5b0586e0d47f30e1/aiohttp-3.12.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:48e43e075c6a438937c4de48ec30fa8ad8e6dfef122a038847456bfe7b947b63", size = 465426 },
+    { url = "https://files.pythonhosted.org/packages/de/dd/525ed198a0bb674a323e93e4d928443a680860802c44fa7922d39436b48b/aiohttp-3.12.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:077b4488411a9724cecc436cbc8c133e0d61e694995b8de51aaf351c7578949d", size = 1704252 },
+    { url = "https://files.pythonhosted.org/packages/d8/b1/01e542aed560a968f692ab4fc4323286e8bc4daae83348cd63588e4f33e3/aiohttp-3.12.14-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d8c35632575653f297dcbc9546305b2c1133391089ab925a6a3706dfa775ccab", size = 1685514 },
+    { url = "https://files.pythonhosted.org/packages/b3/06/93669694dc5fdabdc01338791e70452d60ce21ea0946a878715688d5a191/aiohttp-3.12.14-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b8ce87963f0035c6834b28f061df90cf525ff7c9b6283a8ac23acee6502afd4", size = 1737586 },
+    { url = "https://files.pythonhosted.org/packages/a5/3a/18991048ffc1407ca51efb49ba8bcc1645961f97f563a6c480cdf0286310/aiohttp-3.12.14-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0a2cf66e32a2563bb0766eb24eae7e9a269ac0dc48db0aae90b575dc9583026", size = 1786958 },
+    { url = "https://files.pythonhosted.org/packages/30/a8/81e237f89a32029f9b4a805af6dffc378f8459c7b9942712c809ff9e76e5/aiohttp-3.12.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdea089caf6d5cde975084a884c72d901e36ef9c2fd972c9f51efbbc64e96fbd", size = 1709287 },
+    { url = "https://files.pythonhosted.org/packages/8c/e3/bd67a11b0fe7fc12c6030473afd9e44223d456f500f7cf526dbaa259ae46/aiohttp-3.12.14-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a7865f27db67d49e81d463da64a59365ebd6b826e0e4847aa111056dcb9dc88", size = 1622990 },
+    { url = "https://files.pythonhosted.org/packages/83/ba/e0cc8e0f0d9ce0904e3cf2d6fa41904e379e718a013c721b781d53dcbcca/aiohttp-3.12.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0ab5b38a6a39781d77713ad930cb5e7feea6f253de656a5f9f281a8f5931b086", size = 1676015 },
+    { url = "https://files.pythonhosted.org/packages/d8/b3/1e6c960520bda094c48b56de29a3d978254637ace7168dd97ddc273d0d6c/aiohttp-3.12.14-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9b3b15acee5c17e8848d90a4ebc27853f37077ba6aec4d8cb4dbbea56d156933", size = 1707678 },
+    { url = "https://files.pythonhosted.org/packages/0a/19/929a3eb8c35b7f9f076a462eaa9830b32c7f27d3395397665caa5e975614/aiohttp-3.12.14-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e4c972b0bdaac167c1e53e16a16101b17c6d0ed7eac178e653a07b9f7fad7151", size = 1650274 },
+    { url = "https://files.pythonhosted.org/packages/22/e5/81682a6f20dd1b18ce3d747de8eba11cbef9b270f567426ff7880b096b48/aiohttp-3.12.14-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7442488b0039257a3bdbc55f7209587911f143fca11df9869578db6c26feeeb8", size = 1726408 },
+    { url = "https://files.pythonhosted.org/packages/8c/17/884938dffaa4048302985483f77dfce5ac18339aad9b04ad4aaa5e32b028/aiohttp-3.12.14-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f68d3067eecb64c5e9bab4a26aa11bd676f4c70eea9ef6536b0a4e490639add3", size = 1759879 },
+    { url = "https://files.pythonhosted.org/packages/95/78/53b081980f50b5cf874359bde707a6eacd6c4be3f5f5c93937e48c9d0025/aiohttp-3.12.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f88d3704c8b3d598a08ad17d06006cb1ca52a1182291f04979e305c8be6c9758", size = 1708770 },
+    { url = "https://files.pythonhosted.org/packages/ed/91/228eeddb008ecbe3ffa6c77b440597fdf640307162f0c6488e72c5a2d112/aiohttp-3.12.14-cp313-cp313-win32.whl", hash = "sha256:a3c99ab19c7bf375c4ae3debd91ca5d394b98b6089a03231d4c580ef3c2ae4c5", size = 421688 },
+    { url = "https://files.pythonhosted.org/packages/66/5f/8427618903343402fdafe2850738f735fd1d9409d2a8f9bcaae5e630d3ba/aiohttp-3.12.14-cp313-cp313-win_amd64.whl", hash = "sha256:3f8aad695e12edc9d571f878c62bedc91adf30c760c8632f09663e5f564f4baa", size = 448098 },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490 },
+]
+
+[[package]]
+name = "altair"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/b1/f2969c7bdb8ad8bbdda031687defdce2c19afba2aa2c8e1d2a17f78376d8/altair-5.5.0.tar.gz", hash = "sha256:d960ebe6178c56de3855a68c47b516be38640b73fb3b5111c2a9ca90546dd73d", size = 705305 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/f3/0b6ced594e51cc95d8c1fc1640d3623770d01e4969d29c0bd09945fafefa/altair-5.5.0-py3-none-any.whl", hash = "sha256:91a310b926508d560fe0148d02a194f38b824122641ef528113d029fcd129f8c", size = 731200 },
 ]
 
 [[package]]
@@ -67,12 +196,82 @@ wheels = [
 ]
 
 [[package]]
+name = "asciidoc"
+version = "10.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e7/315a82f2d256e9270977aa3c15e8fe281fd7c40b8e2a0b97e0cb61ca8fa0/asciidoc-10.2.1.tar.gz", hash = "sha256:d9f13c285981b3c7eb660d02ca0a2779981e88d48105de81bb40445e60dddb83", size = 230179 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/1f/87941eaa96e86aa22086064f67e4187e2710fb76c147312979ea29278dac/asciidoc-10.2.1-py2.py3-none-any.whl", hash = "sha256:3f277a636b617c9ce7e0b87bcaea51f144500e9a5c8a6488421ee24594850d40", size = 272433 },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918 },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233 },
+]
+
+[[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815 },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285 },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458 },
+]
+
+[[package]]
+name = "bs4"
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/aa/4acaf814ff901145da37332e05bb510452ebed97bc9602695059dd46ef39/bs4-0.0.2.tar.gz", hash = "sha256:a48685c58f50fe127722417bae83fe6badf500d54b55f7e39ffe43b798653925", size = 698 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl", hash = "sha256:abf8742c0805ef7f662dce4b51cca104cffe52b835238afc169142ab9b3fbccc", size = 1189 },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/89/817ad5d0411f136c484d535952aef74af9b25e0d99e90cdffbe121e6d628/cachetools-6.1.0.tar.gz", hash = "sha256:b4c4f404392848db3ce7aac34950d17be4d864da4b8b66911008e430bc544587", size = 30714 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/f0/2ef431fe4141f5e334759d73e81120492b23b2824336883a91ac04ba710b/cachetools-6.1.0-py3-none-any.whl", hash = "sha256:1c7bb3cf9193deaf3508b7c5f2a79986c13ea38965c5adcff1f84519cf39163e", size = 11189 },
 ]
 
 [[package]]
@@ -139,6 +338,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469 },
     { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475 },
     { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009 },
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
 ]
 
 [[package]]
@@ -236,6 +444,51 @@ wheels = [
 ]
 
 [[package]]
+name = "content-core"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ai-prompter" },
+    { name = "aiohttp" },
+    { name = "asciidoc" },
+    { name = "bs4" },
+    { name = "dicttoxml" },
+    { name = "esperanto" },
+    { name = "firecrawl-py" },
+    { name = "jinja2" },
+    { name = "langdetect" },
+    { name = "langgraph" },
+    { name = "loguru" },
+    { name = "moviepy" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "pymupdf" },
+    { name = "python-docx" },
+    { name = "python-dotenv" },
+    { name = "python-magic" },
+    { name = "python-magic-bin", marker = "sys_platform == 'win32'" },
+    { name = "python-pptx" },
+    { name = "pytubefix" },
+    { name = "readability-lxml" },
+    { name = "validators" },
+    { name = "youtube-transcript-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/f9/455c408b1370103be09bcf23b09a4e27784b30ee69431ec3dceaca1350aa/content_core-1.2.3.tar.gz", hash = "sha256:99b40f0620bbbcbc7b05cad6c983b5629dc1aec2366dc375bfa3975e5fbcf29f", size = 20551768 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/16/29579f120cf45e66c2a0adb4a4eac37713ed29211b8314b69c9f10374bc7/content_core-1.2.3-py3-none-any.whl", hash = "sha256:9b8fbba5609c5e87ed176531fb9106568216482646ae9cffe787cf4fb4b66405", size = 164423 },
+]
+
+[[package]]
+name = "cssselect"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/0a/c3ea9573b1dc2e151abfe88c7fe0c26d1892fe6ed02d0cdb30f0d57029d5/cssselect-1.3.0.tar.gz", hash = "sha256:57f8a99424cfab289a1b6a816a43075a4b00948c86b4dcf3ef4ee7e15f7ab0c7", size = 42870 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/58/257350f7db99b4ae12b614a36256d9cc870d71d9e451e79c2dc3b23d7c3c/cssselect-1.3.0-py3-none-any.whl", hash = "sha256:56d1bf3e198080cc1667e137bc51de9cadfca259f03c2d4e09037b3e01e30f0d", size = 18786 },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.14"
 source = { registry = "https://pypi.org/simple" }
@@ -270,6 +523,24 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604 },
+]
+
+[[package]]
+name = "dicttoxml"
+version = "1.7.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/c9/3132427f9e64d572688e6a1cbe3d542d1a03f676b81fb600f3d1fd7d2ec5/dicttoxml-1.7.16.tar.gz", hash = "sha256:6f36ce644881db5cd8940bee9b7cb3f3f6b7b327ba8a67d83d3e2caa0538bf9d", size = 39314 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/40/9d521973cae7f7ef8b1f0d0e28a3db0f851c1f1dca45d4c2ed5360bb7246/dicttoxml-1.7.16-py3-none-any.whl", hash = "sha256:8677671496d0d38e66c7179f82a7e9059f94887777955dc71b0ac602ee637c26", size = 24155 },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -292,11 +563,20 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059 },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
 wheels = [
@@ -310,6 +590,141 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
+]
+
+[[package]]
+name = "firecrawl-py"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "nest-asyncio" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/c7/f9f41de0cbe0e90c1e04470b7deeebd73f7bf7cc009d21d57b8d0d339710/firecrawl_py-2.15.0.tar.gz", hash = "sha256:8bc8eea586f1fc81bac8692faa34f362050ff8045298b71d04140239c843349b", size = 39869 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/69/bd42f86256158913dd573734ca1f1e928692da88508bf1c8da170c9c7027/firecrawl_py-2.15.0-py3-none-any.whl", hash = "sha256:6e4c53f029fe4784854549cf2760a7ea6a7faa2a098ce9fd49dd85e2f7004186", size = 75435 },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/b1/b64018016eeb087db503b038296fd782586432b9c077fc5c7839e9cb6ef6/frozenlist-1.7.0.tar.gz", hash = "sha256:2e310d81923c2437ea8670467121cc3e9b0f76d3043cc1d2331d56c7fb7a3a8f", size = 45078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/36/0da0a49409f6b47cc2d060dc8c9040b897b5902a8a4e37d9bc1deb11f680/frozenlist-1.7.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cc4df77d638aa2ed703b878dd093725b72a824c3c546c076e8fdf276f78ee84a", size = 81304 },
+    { url = "https://files.pythonhosted.org/packages/77/f0/77c11d13d39513b298e267b22eb6cb559c103d56f155aa9a49097221f0b6/frozenlist-1.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:716a9973a2cc963160394f701964fe25012600f3d311f60c790400b00e568b61", size = 47735 },
+    { url = "https://files.pythonhosted.org/packages/37/12/9d07fa18971a44150593de56b2f2947c46604819976784bcf6ea0d5db43b/frozenlist-1.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a0fd1bad056a3600047fb9462cff4c5322cebc59ebf5d0a3725e0ee78955001d", size = 46775 },
+    { url = "https://files.pythonhosted.org/packages/70/34/f73539227e06288fcd1f8a76853e755b2b48bca6747e99e283111c18bcd4/frozenlist-1.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3789ebc19cb811163e70fe2bd354cea097254ce6e707ae42e56f45e31e96cb8e", size = 224644 },
+    { url = "https://files.pythonhosted.org/packages/fb/68/c1d9c2f4a6e438e14613bad0f2973567586610cc22dcb1e1241da71de9d3/frozenlist-1.7.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af369aa35ee34f132fcfad5be45fbfcde0e3a5f6a1ec0712857f286b7d20cca9", size = 222125 },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/98e8f9a515228d708344d7c6986752be3e3192d1795f748c24bcf154ad99/frozenlist-1.7.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac64b6478722eeb7a3313d494f8342ef3478dff539d17002f849101b212ef97c", size = 233455 },
+    { url = "https://files.pythonhosted.org/packages/79/df/8a11bcec5600557f40338407d3e5bea80376ed1c01a6c0910fcfdc4b8993/frozenlist-1.7.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f89f65d85774f1797239693cef07ad4c97fdd0639544bad9ac4b869782eb1981", size = 227339 },
+    { url = "https://files.pythonhosted.org/packages/50/82/41cb97d9c9a5ff94438c63cc343eb7980dac4187eb625a51bdfdb7707314/frozenlist-1.7.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1073557c941395fdfcfac13eb2456cb8aad89f9de27bae29fabca8e563b12615", size = 212969 },
+    { url = "https://files.pythonhosted.org/packages/13/47/f9179ee5ee4f55629e4f28c660b3fdf2775c8bfde8f9c53f2de2d93f52a9/frozenlist-1.7.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ed8d2fa095aae4bdc7fdd80351009a48d286635edffee66bf865e37a9125c50", size = 222862 },
+    { url = "https://files.pythonhosted.org/packages/1a/52/df81e41ec6b953902c8b7e3a83bee48b195cb0e5ec2eabae5d8330c78038/frozenlist-1.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:24c34bea555fe42d9f928ba0a740c553088500377448febecaa82cc3e88aa1fa", size = 222492 },
+    { url = "https://files.pythonhosted.org/packages/84/17/30d6ea87fa95a9408245a948604b82c1a4b8b3e153cea596421a2aef2754/frozenlist-1.7.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:69cac419ac6a6baad202c85aaf467b65ac860ac2e7f2ac1686dc40dbb52f6577", size = 238250 },
+    { url = "https://files.pythonhosted.org/packages/8f/00/ecbeb51669e3c3df76cf2ddd66ae3e48345ec213a55e3887d216eb4fbab3/frozenlist-1.7.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:960d67d0611f4c87da7e2ae2eacf7ea81a5be967861e0c63cf205215afbfac59", size = 218720 },
+    { url = "https://files.pythonhosted.org/packages/1a/c0/c224ce0e0eb31cc57f67742071bb470ba8246623c1823a7530be0e76164c/frozenlist-1.7.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:41be2964bd4b15bf575e5daee5a5ce7ed3115320fb3c2b71fca05582ffa4dc9e", size = 232585 },
+    { url = "https://files.pythonhosted.org/packages/55/3c/34cb694abf532f31f365106deebdeac9e45c19304d83cf7d51ebbb4ca4d1/frozenlist-1.7.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:46d84d49e00c9429238a7ce02dc0be8f6d7cd0cd405abd1bebdc991bf27c15bd", size = 234248 },
+    { url = "https://files.pythonhosted.org/packages/98/c0/2052d8b6cecda2e70bd81299e3512fa332abb6dcd2969b9c80dfcdddbf75/frozenlist-1.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:15900082e886edb37480335d9d518cec978afc69ccbc30bd18610b7c1b22a718", size = 221621 },
+    { url = "https://files.pythonhosted.org/packages/c5/bf/7dcebae315436903b1d98ffb791a09d674c88480c158aa171958a3ac07f0/frozenlist-1.7.0-cp310-cp310-win32.whl", hash = "sha256:400ddd24ab4e55014bba442d917203c73b2846391dd42ca5e38ff52bb18c3c5e", size = 39578 },
+    { url = "https://files.pythonhosted.org/packages/8f/5f/f69818f017fa9a3d24d1ae39763e29b7f60a59e46d5f91b9c6b21622f4cd/frozenlist-1.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:6eb93efb8101ef39d32d50bce242c84bcbddb4f7e9febfa7b524532a239b4464", size = 43830 },
+    { url = "https://files.pythonhosted.org/packages/34/7e/803dde33760128acd393a27eb002f2020ddb8d99d30a44bfbaab31c5f08a/frozenlist-1.7.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:aa51e147a66b2d74de1e6e2cf5921890de6b0f4820b257465101d7f37b49fb5a", size = 82251 },
+    { url = "https://files.pythonhosted.org/packages/75/a9/9c2c5760b6ba45eae11334db454c189d43d34a4c0b489feb2175e5e64277/frozenlist-1.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9b35db7ce1cd71d36ba24f80f0c9e7cff73a28d7a74e91fe83e23d27c7828750", size = 48183 },
+    { url = "https://files.pythonhosted.org/packages/47/be/4038e2d869f8a2da165f35a6befb9158c259819be22eeaf9c9a8f6a87771/frozenlist-1.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34a69a85e34ff37791e94542065c8416c1afbf820b68f720452f636d5fb990cd", size = 47107 },
+    { url = "https://files.pythonhosted.org/packages/79/26/85314b8a83187c76a37183ceed886381a5f992975786f883472fcb6dc5f2/frozenlist-1.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a646531fa8d82c87fe4bb2e596f23173caec9185bfbca5d583b4ccfb95183e2", size = 237333 },
+    { url = "https://files.pythonhosted.org/packages/1f/fd/e5b64f7d2c92a41639ffb2ad44a6a82f347787abc0c7df5f49057cf11770/frozenlist-1.7.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:79b2ffbba483f4ed36a0f236ccb85fbb16e670c9238313709638167670ba235f", size = 231724 },
+    { url = "https://files.pythonhosted.org/packages/20/fb/03395c0a43a5976af4bf7534759d214405fbbb4c114683f434dfdd3128ef/frozenlist-1.7.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a26f205c9ca5829cbf82bb2a84b5c36f7184c4316617d7ef1b271a56720d6b30", size = 245842 },
+    { url = "https://files.pythonhosted.org/packages/d0/15/c01c8e1dffdac5d9803507d824f27aed2ba76b6ed0026fab4d9866e82f1f/frozenlist-1.7.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bcacfad3185a623fa11ea0e0634aac7b691aa925d50a440f39b458e41c561d98", size = 239767 },
+    { url = "https://files.pythonhosted.org/packages/14/99/3f4c6fe882c1f5514b6848aa0a69b20cb5e5d8e8f51a339d48c0e9305ed0/frozenlist-1.7.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72c1b0fe8fe451b34f12dce46445ddf14bd2a5bcad7e324987194dc8e3a74c86", size = 224130 },
+    { url = "https://files.pythonhosted.org/packages/4d/83/220a374bd7b2aeba9d0725130665afe11de347d95c3620b9b82cc2fcab97/frozenlist-1.7.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61d1a5baeaac6c0798ff6edfaeaa00e0e412d49946c53fae8d4b8e8b3566c4ae", size = 235301 },
+    { url = "https://files.pythonhosted.org/packages/03/3c/3e3390d75334a063181625343e8daab61b77e1b8214802cc4e8a1bb678fc/frozenlist-1.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7edf5c043c062462f09b6820de9854bf28cc6cc5b6714b383149745e287181a8", size = 234606 },
+    { url = "https://files.pythonhosted.org/packages/23/1e/58232c19608b7a549d72d9903005e2d82488f12554a32de2d5fb59b9b1ba/frozenlist-1.7.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:d50ac7627b3a1bd2dcef6f9da89a772694ec04d9a61b66cf87f7d9446b4a0c31", size = 248372 },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/e4a567e01702a88a74ce8a324691e62a629bf47d4f8607f24bf1c7216e7f/frozenlist-1.7.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ce48b2fece5aeb45265bb7a58259f45027db0abff478e3077e12b05b17fb9da7", size = 229860 },
+    { url = "https://files.pythonhosted.org/packages/73/a6/63b3374f7d22268b41a9db73d68a8233afa30ed164c46107b33c4d18ecdd/frozenlist-1.7.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:fe2365ae915a1fafd982c146754e1de6ab3478def8a59c86e1f7242d794f97d5", size = 245893 },
+    { url = "https://files.pythonhosted.org/packages/6d/eb/d18b3f6e64799a79673c4ba0b45e4cfbe49c240edfd03a68be20002eaeaa/frozenlist-1.7.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:45a6f2fdbd10e074e8814eb98b05292f27bad7d1883afbe009d96abdcf3bc898", size = 246323 },
+    { url = "https://files.pythonhosted.org/packages/5a/f5/720f3812e3d06cd89a1d5db9ff6450088b8f5c449dae8ffb2971a44da506/frozenlist-1.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:21884e23cffabb157a9dd7e353779077bf5b8f9a58e9b262c6caad2ef5f80a56", size = 233149 },
+    { url = "https://files.pythonhosted.org/packages/69/68/03efbf545e217d5db8446acfd4c447c15b7c8cf4dbd4a58403111df9322d/frozenlist-1.7.0-cp311-cp311-win32.whl", hash = "sha256:284d233a8953d7b24f9159b8a3496fc1ddc00f4db99c324bd5fb5f22d8698ea7", size = 39565 },
+    { url = "https://files.pythonhosted.org/packages/58/17/fe61124c5c333ae87f09bb67186d65038834a47d974fc10a5fadb4cc5ae1/frozenlist-1.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:387cbfdcde2f2353f19c2f66bbb52406d06ed77519ac7ee21be0232147c2592d", size = 44019 },
+    { url = "https://files.pythonhosted.org/packages/ef/a2/c8131383f1e66adad5f6ecfcce383d584ca94055a34d683bbb24ac5f2f1c/frozenlist-1.7.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3dbf9952c4bb0e90e98aec1bd992b3318685005702656bc6f67c1a32b76787f2", size = 81424 },
+    { url = "https://files.pythonhosted.org/packages/4c/9d/02754159955088cb52567337d1113f945b9e444c4960771ea90eb73de8db/frozenlist-1.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1f5906d3359300b8a9bb194239491122e6cf1444c2efb88865426f170c262cdb", size = 47952 },
+    { url = "https://files.pythonhosted.org/packages/01/7a/0046ef1bd6699b40acd2067ed6d6670b4db2f425c56980fa21c982c2a9db/frozenlist-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3dabd5a8f84573c8d10d8859a50ea2dec01eea372031929871368c09fa103478", size = 46688 },
+    { url = "https://files.pythonhosted.org/packages/d6/a2/a910bafe29c86997363fb4c02069df4ff0b5bc39d33c5198b4e9dd42d8f8/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa57daa5917f1738064f302bf2626281a1cb01920c32f711fbc7bc36111058a8", size = 243084 },
+    { url = "https://files.pythonhosted.org/packages/64/3e/5036af9d5031374c64c387469bfcc3af537fc0f5b1187d83a1cf6fab1639/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c193dda2b6d49f4c4398962810fa7d7c78f032bf45572b3e04dd5249dff27e08", size = 233524 },
+    { url = "https://files.pythonhosted.org/packages/06/39/6a17b7c107a2887e781a48ecf20ad20f1c39d94b2a548c83615b5b879f28/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfe2b675cf0aaa6d61bf8fbffd3c274b3c9b7b1623beb3809df8a81399a4a9c4", size = 248493 },
+    { url = "https://files.pythonhosted.org/packages/be/00/711d1337c7327d88c44d91dd0f556a1c47fb99afc060ae0ef66b4d24793d/frozenlist-1.7.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8fc5d5cda37f62b262405cf9652cf0856839c4be8ee41be0afe8858f17f4c94b", size = 244116 },
+    { url = "https://files.pythonhosted.org/packages/24/fe/74e6ec0639c115df13d5850e75722750adabdc7de24e37e05a40527ca539/frozenlist-1.7.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0d5ce521d1dd7d620198829b87ea002956e4319002ef0bc8d3e6d045cb4646e", size = 224557 },
+    { url = "https://files.pythonhosted.org/packages/8d/db/48421f62a6f77c553575201e89048e97198046b793f4a089c79a6e3268bd/frozenlist-1.7.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:488d0a7d6a0008ca0db273c542098a0fa9e7dfaa7e57f70acef43f32b3f69dca", size = 241820 },
+    { url = "https://files.pythonhosted.org/packages/1d/fa/cb4a76bea23047c8462976ea7b7a2bf53997a0ca171302deae9d6dd12096/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:15a7eaba63983d22c54d255b854e8108e7e5f3e89f647fc854bd77a237e767df", size = 236542 },
+    { url = "https://files.pythonhosted.org/packages/5d/32/476a4b5cfaa0ec94d3f808f193301debff2ea42288a099afe60757ef6282/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1eaa7e9c6d15df825bf255649e05bd8a74b04a4d2baa1ae46d9c2d00b2ca2cb5", size = 249350 },
+    { url = "https://files.pythonhosted.org/packages/8d/ba/9a28042f84a6bf8ea5dbc81cfff8eaef18d78b2a1ad9d51c7bc5b029ad16/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e4389e06714cfa9d47ab87f784a7c5be91d3934cd6e9a7b85beef808297cc025", size = 225093 },
+    { url = "https://files.pythonhosted.org/packages/bc/29/3a32959e68f9cf000b04e79ba574527c17e8842e38c91d68214a37455786/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:73bd45e1488c40b63fe5a7df892baf9e2a4d4bb6409a2b3b78ac1c6236178e01", size = 245482 },
+    { url = "https://files.pythonhosted.org/packages/80/e8/edf2f9e00da553f07f5fa165325cfc302dead715cab6ac8336a5f3d0adc2/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99886d98e1643269760e5fe0df31e5ae7050788dd288947f7f007209b8c33f08", size = 249590 },
+    { url = "https://files.pythonhosted.org/packages/1c/80/9a0eb48b944050f94cc51ee1c413eb14a39543cc4f760ed12657a5a3c45a/frozenlist-1.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:290a172aae5a4c278c6da8a96222e6337744cd9c77313efe33d5670b9f65fc43", size = 237785 },
+    { url = "https://files.pythonhosted.org/packages/f3/74/87601e0fb0369b7a2baf404ea921769c53b7ae00dee7dcfe5162c8c6dbf0/frozenlist-1.7.0-cp312-cp312-win32.whl", hash = "sha256:426c7bc70e07cfebc178bc4c2bf2d861d720c4fff172181eeb4a4c41d4ca2ad3", size = 39487 },
+    { url = "https://files.pythonhosted.org/packages/0b/15/c026e9a9fc17585a9d461f65d8593d281fedf55fbf7eb53f16c6df2392f9/frozenlist-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:563b72efe5da92e02eb68c59cb37205457c977aa7a449ed1b37e6939e5c47c6a", size = 43874 },
+    { url = "https://files.pythonhosted.org/packages/24/90/6b2cebdabdbd50367273c20ff6b57a3dfa89bd0762de02c3a1eb42cb6462/frozenlist-1.7.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee80eeda5e2a4e660651370ebffd1286542b67e268aa1ac8d6dbe973120ef7ee", size = 79791 },
+    { url = "https://files.pythonhosted.org/packages/83/2e/5b70b6a3325363293fe5fc3ae74cdcbc3e996c2a11dde2fd9f1fb0776d19/frozenlist-1.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d1a81c85417b914139e3a9b995d4a1c84559afc839a93cf2cb7f15e6e5f6ed2d", size = 47165 },
+    { url = "https://files.pythonhosted.org/packages/f4/25/a0895c99270ca6966110f4ad98e87e5662eab416a17e7fd53c364bf8b954/frozenlist-1.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cbb65198a9132ebc334f237d7b0df163e4de83fb4f2bdfe46c1e654bdb0c5d43", size = 45881 },
+    { url = "https://files.pythonhosted.org/packages/19/7c/71bb0bbe0832793c601fff68cd0cf6143753d0c667f9aec93d3c323f4b55/frozenlist-1.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dab46c723eeb2c255a64f9dc05b8dd601fde66d6b19cdb82b2e09cc6ff8d8b5d", size = 232409 },
+    { url = "https://files.pythonhosted.org/packages/c0/45/ed2798718910fe6eb3ba574082aaceff4528e6323f9a8570be0f7028d8e9/frozenlist-1.7.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6aeac207a759d0dedd2e40745575ae32ab30926ff4fa49b1635def65806fddee", size = 225132 },
+    { url = "https://files.pythonhosted.org/packages/ba/e2/8417ae0f8eacb1d071d4950f32f229aa6bf68ab69aab797b72a07ea68d4f/frozenlist-1.7.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bd8c4e58ad14b4fa7802b8be49d47993182fdd4023393899632c88fd8cd994eb", size = 237638 },
+    { url = "https://files.pythonhosted.org/packages/f8/b7/2ace5450ce85f2af05a871b8c8719b341294775a0a6c5585d5e6170f2ce7/frozenlist-1.7.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04fb24d104f425da3540ed83cbfc31388a586a7696142004c577fa61c6298c3f", size = 233539 },
+    { url = "https://files.pythonhosted.org/packages/46/b9/6989292c5539553dba63f3c83dc4598186ab2888f67c0dc1d917e6887db6/frozenlist-1.7.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6a5c505156368e4ea6b53b5ac23c92d7edc864537ff911d2fb24c140bb175e60", size = 215646 },
+    { url = "https://files.pythonhosted.org/packages/72/31/bc8c5c99c7818293458fe745dab4fd5730ff49697ccc82b554eb69f16a24/frozenlist-1.7.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bd7eb96a675f18aa5c553eb7ddc24a43c8c18f22e1f9925528128c052cdbe00", size = 232233 },
+    { url = "https://files.pythonhosted.org/packages/59/52/460db4d7ba0811b9ccb85af996019f5d70831f2f5f255f7cc61f86199795/frozenlist-1.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:05579bf020096fe05a764f1f84cd104a12f78eaab68842d036772dc6d4870b4b", size = 227996 },
+    { url = "https://files.pythonhosted.org/packages/ba/c9/f4b39e904c03927b7ecf891804fd3b4df3db29b9e487c6418e37988d6e9d/frozenlist-1.7.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:376b6222d114e97eeec13d46c486facd41d4f43bab626b7c3f6a8b4e81a5192c", size = 242280 },
+    { url = "https://files.pythonhosted.org/packages/b8/33/3f8d6ced42f162d743e3517781566b8481322be321b486d9d262adf70bfb/frozenlist-1.7.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0aa7e176ebe115379b5b1c95b4096fb1c17cce0847402e227e712c27bdb5a949", size = 217717 },
+    { url = "https://files.pythonhosted.org/packages/3e/e8/ad683e75da6ccef50d0ab0c2b2324b32f84fc88ceee778ed79b8e2d2fe2e/frozenlist-1.7.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3fbba20e662b9c2130dc771e332a99eff5da078b2b2648153a40669a6d0e36ca", size = 236644 },
+    { url = "https://files.pythonhosted.org/packages/b2/14/8d19ccdd3799310722195a72ac94ddc677541fb4bef4091d8e7775752360/frozenlist-1.7.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f3f4410a0a601d349dd406b5713fec59b4cee7e71678d5b17edda7f4655a940b", size = 238879 },
+    { url = "https://files.pythonhosted.org/packages/ce/13/c12bf657494c2fd1079a48b2db49fa4196325909249a52d8f09bc9123fd7/frozenlist-1.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e2cdfaaec6a2f9327bf43c933c0319a7c429058e8537c508964a133dffee412e", size = 232502 },
+    { url = "https://files.pythonhosted.org/packages/d7/8b/e7f9dfde869825489382bc0d512c15e96d3964180c9499efcec72e85db7e/frozenlist-1.7.0-cp313-cp313-win32.whl", hash = "sha256:5fc4df05a6591c7768459caba1b342d9ec23fa16195e744939ba5914596ae3e1", size = 39169 },
+    { url = "https://files.pythonhosted.org/packages/35/89/a487a98d94205d85745080a37860ff5744b9820a2c9acbcdd9440bfddf98/frozenlist-1.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:52109052b9791a3e6b5d1b65f4b909703984b770694d3eb64fad124c835d7cba", size = 43219 },
+    { url = "https://files.pythonhosted.org/packages/56/d5/5c4cf2319a49eddd9dd7145e66c4866bdc6f3dbc67ca3d59685149c11e0d/frozenlist-1.7.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a6f86e4193bb0e235ef6ce3dde5cbabed887e0b11f516ce8a0f4d3b33078ec2d", size = 84345 },
+    { url = "https://files.pythonhosted.org/packages/a4/7d/ec2c1e1dc16b85bc9d526009961953df9cec8481b6886debb36ec9107799/frozenlist-1.7.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:82d664628865abeb32d90ae497fb93df398a69bb3434463d172b80fc25b0dd7d", size = 48880 },
+    { url = "https://files.pythonhosted.org/packages/69/86/f9596807b03de126e11e7d42ac91e3d0b19a6599c714a1989a4e85eeefc4/frozenlist-1.7.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:912a7e8375a1c9a68325a902f3953191b7b292aa3c3fb0d71a216221deca460b", size = 48498 },
+    { url = "https://files.pythonhosted.org/packages/5e/cb/df6de220f5036001005f2d726b789b2c0b65f2363b104bbc16f5be8084f8/frozenlist-1.7.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9537c2777167488d539bc5de2ad262efc44388230e5118868e172dd4a552b146", size = 292296 },
+    { url = "https://files.pythonhosted.org/packages/83/1f/de84c642f17c8f851a2905cee2dae401e5e0daca9b5ef121e120e19aa825/frozenlist-1.7.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f34560fb1b4c3e30ba35fa9a13894ba39e5acfc5f60f57d8accde65f46cc5e74", size = 273103 },
+    { url = "https://files.pythonhosted.org/packages/88/3c/c840bfa474ba3fa13c772b93070893c6e9d5c0350885760376cbe3b6c1b3/frozenlist-1.7.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:acd03d224b0175f5a850edc104ac19040d35419eddad04e7cf2d5986d98427f1", size = 292869 },
+    { url = "https://files.pythonhosted.org/packages/a6/1c/3efa6e7d5a39a1d5ef0abeb51c48fb657765794a46cf124e5aca2c7a592c/frozenlist-1.7.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2038310bc582f3d6a09b3816ab01737d60bf7b1ec70f5356b09e84fb7408ab1", size = 291467 },
+    { url = "https://files.pythonhosted.org/packages/4f/00/d5c5e09d4922c395e2f2f6b79b9a20dab4b67daaf78ab92e7729341f61f6/frozenlist-1.7.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b8c05e4c8e5f36e5e088caa1bf78a687528f83c043706640a92cb76cd6999384", size = 266028 },
+    { url = "https://files.pythonhosted.org/packages/4e/27/72765be905619dfde25a7f33813ac0341eb6b076abede17a2e3fbfade0cb/frozenlist-1.7.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:765bb588c86e47d0b68f23c1bee323d4b703218037765dcf3f25c838c6fecceb", size = 284294 },
+    { url = "https://files.pythonhosted.org/packages/88/67/c94103a23001b17808eb7dd1200c156bb69fb68e63fcf0693dde4cd6228c/frozenlist-1.7.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:32dc2e08c67d86d0969714dd484fd60ff08ff81d1a1e40a77dd34a387e6ebc0c", size = 281898 },
+    { url = "https://files.pythonhosted.org/packages/42/34/a3e2c00c00f9e2a9db5653bca3fec306349e71aff14ae45ecc6d0951dd24/frozenlist-1.7.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:c0303e597eb5a5321b4de9c68e9845ac8f290d2ab3f3e2c864437d3c5a30cd65", size = 290465 },
+    { url = "https://files.pythonhosted.org/packages/bb/73/f89b7fbce8b0b0c095d82b008afd0590f71ccb3dee6eee41791cf8cd25fd/frozenlist-1.7.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:a47f2abb4e29b3a8d0b530f7c3598badc6b134562b1a5caee867f7c62fee51e3", size = 266385 },
+    { url = "https://files.pythonhosted.org/packages/cd/45/e365fdb554159462ca12df54bc59bfa7a9a273ecc21e99e72e597564d1ae/frozenlist-1.7.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:3d688126c242a6fabbd92e02633414d40f50bb6002fa4cf995a1d18051525657", size = 288771 },
+    { url = "https://files.pythonhosted.org/packages/00/11/47b6117002a0e904f004d70ec5194fe9144f117c33c851e3d51c765962d0/frozenlist-1.7.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:4e7e9652b3d367c7bd449a727dc79d5043f48b88d0cbfd4f9f1060cf2b414104", size = 288206 },
+    { url = "https://files.pythonhosted.org/packages/40/37/5f9f3c3fd7f7746082ec67bcdc204db72dad081f4f83a503d33220a92973/frozenlist-1.7.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1a85e345b4c43db8b842cab1feb41be5cc0b10a1830e6295b69d7310f99becaf", size = 282620 },
+    { url = "https://files.pythonhosted.org/packages/0b/31/8fbc5af2d183bff20f21aa743b4088eac4445d2bb1cdece449ae80e4e2d1/frozenlist-1.7.0-cp313-cp313t-win32.whl", hash = "sha256:3a14027124ddb70dfcee5148979998066897e79f89f64b13328595c4bdf77c81", size = 43059 },
+    { url = "https://files.pythonhosted.org/packages/bb/ed/41956f52105b8dbc26e457c5705340c67c8cc2b79f394b79bffc09d0e938/frozenlist-1.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3bf8010d71d4507775f658e9823210b7427be36625b387221642725b515dcf3e", size = 47516 },
+    { url = "https://files.pythonhosted.org/packages/ee/45/b82e3c16be2182bff01179db177fe144d58b5dc787a7d4492c6ed8b9317f/frozenlist-1.7.0-py3-none-any.whl", hash = "sha256:9a5af342e34f7e97caf8c995864c7a396418ae2859cc6fdf1b1073020d516a7e", size = 13106 },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794 },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269", size = 214196 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/9a/4114a9057db2f1462d5c8f8390ab7383925fe1ac012eaa42402ad65c2963/GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110", size = 207599 },
 ]
 
 [[package]]
@@ -574,6 +989,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/d3/1cf5326b923a53515d8f3a2cd442e6d7e94fcc444716e879ea70a0ce3177/jsonschema-4.24.0.tar.gz", hash = "sha256:0b4e8069eb12aedfa881333004bccaec24ecef5a8a6a4b6df142b2cc9599d196", size = 353480 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/3d/023389198f69c722d039351050738d6755376c8fd343e91dc493ea485905/jsonschema-4.24.0-py3-none-any.whl", hash = "sha256:a462455f19f5faf404a7902952b6f0e3ce868f3ee09a359b05eca6673bd8412d", size = 88709 },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437 },
+]
+
+[[package]]
 name = "jupyter-client"
 version = "8.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -672,6 +1114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "langdetect"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474 }
+
+[[package]]
 name = "langgraph"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -756,6 +1207,97 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595 },
+]
+
+[[package]]
+name = "lxml"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/ed/60eb6fa2923602fba988d9ca7c5cdbd7cf25faa795162ed538b527a35411/lxml-6.0.0.tar.gz", hash = "sha256:032e65120339d44cdc3efc326c9f660f5f7205f3a535c1fdbf898b29ea01fb72", size = 4096938 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/e9/9c3ca02fbbb7585116c2e274b354a2d92b5c70561687dd733ec7b2018490/lxml-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:35bc626eec405f745199200ccb5c6b36f202675d204aa29bb52e27ba2b71dea8", size = 8399057 },
+    { url = "https://files.pythonhosted.org/packages/86/25/10a6e9001191854bf283515020f3633b1b1f96fd1b39aa30bf8fff7aa666/lxml-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:246b40f8a4aec341cbbf52617cad8ab7c888d944bfe12a6abd2b1f6cfb6f6082", size = 4569676 },
+    { url = "https://files.pythonhosted.org/packages/f5/a5/378033415ff61d9175c81de23e7ad20a3ffb614df4ffc2ffc86bc6746ffd/lxml-6.0.0-cp310-cp310-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:2793a627e95d119e9f1e19720730472f5543a6d84c50ea33313ce328d870f2dd", size = 5291361 },
+    { url = "https://files.pythonhosted.org/packages/5a/a6/19c87c4f3b9362b08dc5452a3c3bce528130ac9105fc8fff97ce895ce62e/lxml-6.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:46b9ed911f36bfeb6338e0b482e7fe7c27d362c52fde29f221fddbc9ee2227e7", size = 5008290 },
+    { url = "https://files.pythonhosted.org/packages/09/d1/e9b7ad4b4164d359c4d87ed8c49cb69b443225cb495777e75be0478da5d5/lxml-6.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b4790b558bee331a933e08883c423f65bbcd07e278f91b2272489e31ab1e2b4", size = 5163192 },
+    { url = "https://files.pythonhosted.org/packages/56/d6/b3eba234dc1584744b0b374a7f6c26ceee5dc2147369a7e7526e25a72332/lxml-6.0.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2030956cf4886b10be9a0285c6802e078ec2391e1dd7ff3eb509c2c95a69b76", size = 5076973 },
+    { url = "https://files.pythonhosted.org/packages/8e/47/897142dd9385dcc1925acec0c4afe14cc16d310ce02c41fcd9010ac5d15d/lxml-6.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d23854ecf381ab1facc8f353dcd9adeddef3652268ee75297c1164c987c11dc", size = 5297795 },
+    { url = "https://files.pythonhosted.org/packages/fb/db/551ad84515c6f415cea70193a0ff11d70210174dc0563219f4ce711655c6/lxml-6.0.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:43fe5af2d590bf4691531b1d9a2495d7aab2090547eaacd224a3afec95706d76", size = 4776547 },
+    { url = "https://files.pythonhosted.org/packages/e0/14/c4a77ab4f89aaf35037a03c472f1ccc54147191888626079bd05babd6808/lxml-6.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74e748012f8c19b47f7d6321ac929a9a94ee92ef12bc4298c47e8b7219b26541", size = 5124904 },
+    { url = "https://files.pythonhosted.org/packages/70/b4/12ae6a51b8da106adec6a2e9c60f532350a24ce954622367f39269e509b1/lxml-6.0.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:43cfbb7db02b30ad3926e8fceaef260ba2fb7df787e38fa2df890c1ca7966c3b", size = 4805804 },
+    { url = "https://files.pythonhosted.org/packages/a9/b6/2e82d34d49f6219cdcb6e3e03837ca5fb8b7f86c2f35106fb8610ac7f5b8/lxml-6.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34190a1ec4f1e84af256495436b2d196529c3f2094f0af80202947567fdbf2e7", size = 5323477 },
+    { url = "https://files.pythonhosted.org/packages/a1/e6/b83ddc903b05cd08a5723fefd528eee84b0edd07bdf87f6c53a1fda841fd/lxml-6.0.0-cp310-cp310-win32.whl", hash = "sha256:5967fe415b1920a3877a4195e9a2b779249630ee49ece22021c690320ff07452", size = 3613840 },
+    { url = "https://files.pythonhosted.org/packages/40/af/874fb368dd0c663c030acb92612341005e52e281a102b72a4c96f42942e1/lxml-6.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:f3389924581d9a770c6caa4df4e74b606180869043b9073e2cec324bad6e306e", size = 3993584 },
+    { url = "https://files.pythonhosted.org/packages/4a/f4/d296bc22c17d5607653008f6dd7b46afdfda12efd31021705b507df652bb/lxml-6.0.0-cp310-cp310-win_arm64.whl", hash = "sha256:522fe7abb41309e9543b0d9b8b434f2b630c5fdaf6482bee642b34c8c70079c8", size = 3681400 },
+    { url = "https://files.pythonhosted.org/packages/7c/23/828d4cc7da96c611ec0ce6147bbcea2fdbde023dc995a165afa512399bbf/lxml-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4ee56288d0df919e4aac43b539dd0e34bb55d6a12a6562038e8d6f3ed07f9e36", size = 8438217 },
+    { url = "https://files.pythonhosted.org/packages/f1/33/5ac521212c5bcb097d573145d54b2b4a3c9766cda88af5a0e91f66037c6e/lxml-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8dd6dd0e9c1992613ccda2bcb74fc9d49159dbe0f0ca4753f37527749885c25", size = 4590317 },
+    { url = "https://files.pythonhosted.org/packages/2b/2e/45b7ca8bee304c07f54933c37afe7dd4d39ff61ba2757f519dcc71bc5d44/lxml-6.0.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:d7ae472f74afcc47320238b5dbfd363aba111a525943c8a34a1b657c6be934c3", size = 5221628 },
+    { url = "https://files.pythonhosted.org/packages/32/23/526d19f7eb2b85da1f62cffb2556f647b049ebe2a5aa8d4d41b1fb2c7d36/lxml-6.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5592401cdf3dc682194727c1ddaa8aa0f3ddc57ca64fd03226a430b955eab6f6", size = 4949429 },
+    { url = "https://files.pythonhosted.org/packages/ac/cc/f6be27a5c656a43a5344e064d9ae004d4dcb1d3c9d4f323c8189ddfe4d13/lxml-6.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58ffd35bd5425c3c3b9692d078bf7ab851441434531a7e517c4984d5634cd65b", size = 5087909 },
+    { url = "https://files.pythonhosted.org/packages/3b/e6/8ec91b5bfbe6972458bc105aeb42088e50e4b23777170404aab5dfb0c62d/lxml-6.0.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f720a14aa102a38907c6d5030e3d66b3b680c3e6f6bc95473931ea3c00c59967", size = 5031713 },
+    { url = "https://files.pythonhosted.org/packages/33/cf/05e78e613840a40e5be3e40d892c48ad3e475804db23d4bad751b8cadb9b/lxml-6.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2a5e8d207311a0170aca0eb6b160af91adc29ec121832e4ac151a57743a1e1e", size = 5232417 },
+    { url = "https://files.pythonhosted.org/packages/ac/8c/6b306b3e35c59d5f0b32e3b9b6b3b0739b32c0dc42a295415ba111e76495/lxml-6.0.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:2dd1cc3ea7e60bfb31ff32cafe07e24839df573a5e7c2d33304082a5019bcd58", size = 4681443 },
+    { url = "https://files.pythonhosted.org/packages/59/43/0bd96bece5f7eea14b7220476835a60d2b27f8e9ca99c175f37c085cb154/lxml-6.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2cfcf84f1defed7e5798ef4f88aa25fcc52d279be731ce904789aa7ccfb7e8d2", size = 5074542 },
+    { url = "https://files.pythonhosted.org/packages/e2/3d/32103036287a8ca012d8518071f8852c68f2b3bfe048cef2a0202eb05910/lxml-6.0.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:a52a4704811e2623b0324a18d41ad4b9fabf43ce5ff99b14e40a520e2190c851", size = 4729471 },
+    { url = "https://files.pythonhosted.org/packages/ca/a8/7be5d17df12d637d81854bd8648cd329f29640a61e9a72a3f77add4a311b/lxml-6.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c16304bba98f48a28ae10e32a8e75c349dd742c45156f297e16eeb1ba9287a1f", size = 5256285 },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/6cb96174c25e0d749932557c8d51d60c6e292c877b46fae616afa23ed31a/lxml-6.0.0-cp311-cp311-win32.whl", hash = "sha256:f8d19565ae3eb956d84da3ef367aa7def14a2735d05bd275cd54c0301f0d0d6c", size = 3612004 },
+    { url = "https://files.pythonhosted.org/packages/ca/77/6ad43b165dfc6dead001410adeb45e88597b25185f4479b7ca3b16a5808f/lxml-6.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:b2d71cdefda9424adff9a3607ba5bbfc60ee972d73c21c7e3c19e71037574816", size = 4003470 },
+    { url = "https://files.pythonhosted.org/packages/a0/bc/4c50ec0eb14f932a18efc34fc86ee936a66c0eb5f2fe065744a2da8a68b2/lxml-6.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:8a2e76efbf8772add72d002d67a4c3d0958638696f541734304c7f28217a9cab", size = 3682477 },
+    { url = "https://files.pythonhosted.org/packages/89/c3/d01d735c298d7e0ddcedf6f028bf556577e5ab4f4da45175ecd909c79378/lxml-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78718d8454a6e928470d511bf8ac93f469283a45c354995f7d19e77292f26108", size = 8429515 },
+    { url = "https://files.pythonhosted.org/packages/06/37/0e3eae3043d366b73da55a86274a590bae76dc45aa004b7042e6f97803b1/lxml-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:84ef591495ffd3f9dcabffd6391db7bb70d7230b5c35ef5148354a134f56f2be", size = 4601387 },
+    { url = "https://files.pythonhosted.org/packages/a3/28/e1a9a881e6d6e29dda13d633885d13acb0058f65e95da67841c8dd02b4a8/lxml-6.0.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:2930aa001a3776c3e2601cb8e0a15d21b8270528d89cc308be4843ade546b9ab", size = 5228928 },
+    { url = "https://files.pythonhosted.org/packages/9a/55/2cb24ea48aa30c99f805921c1c7860c1f45c0e811e44ee4e6a155668de06/lxml-6.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:219e0431ea8006e15005767f0351e3f7f9143e793e58519dc97fe9e07fae5563", size = 4952289 },
+    { url = "https://files.pythonhosted.org/packages/31/c0/b25d9528df296b9a3306ba21ff982fc5b698c45ab78b94d18c2d6ae71fd9/lxml-6.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bd5913b4972681ffc9718bc2d4c53cde39ef81415e1671ff93e9aa30b46595e7", size = 5111310 },
+    { url = "https://files.pythonhosted.org/packages/e9/af/681a8b3e4f668bea6e6514cbcb297beb6de2b641e70f09d3d78655f4f44c/lxml-6.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:390240baeb9f415a82eefc2e13285016f9c8b5ad71ec80574ae8fa9605093cd7", size = 5025457 },
+    { url = "https://files.pythonhosted.org/packages/99/b6/3a7971aa05b7be7dfebc7ab57262ec527775c2c3c5b2f43675cac0458cad/lxml-6.0.0-cp312-cp312-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d6e200909a119626744dd81bae409fc44134389e03fbf1d68ed2a55a2fb10991", size = 5657016 },
+    { url = "https://files.pythonhosted.org/packages/69/f8/693b1a10a891197143c0673fcce5b75fc69132afa81a36e4568c12c8faba/lxml-6.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ca50bd612438258a91b5b3788c6621c1f05c8c478e7951899f492be42defc0da", size = 5257565 },
+    { url = "https://files.pythonhosted.org/packages/a8/96/e08ff98f2c6426c98c8964513c5dab8d6eb81dadcd0af6f0c538ada78d33/lxml-6.0.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:c24b8efd9c0f62bad0439283c2c795ef916c5a6b75f03c17799775c7ae3c0c9e", size = 4713390 },
+    { url = "https://files.pythonhosted.org/packages/a8/83/6184aba6cc94d7413959f6f8f54807dc318fdcd4985c347fe3ea6937f772/lxml-6.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:afd27d8629ae94c5d863e32ab0e1d5590371d296b87dae0a751fb22bf3685741", size = 5066103 },
+    { url = "https://files.pythonhosted.org/packages/ee/01/8bf1f4035852d0ff2e36a4d9aacdbcc57e93a6cd35a54e05fa984cdf73ab/lxml-6.0.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:54c4855eabd9fc29707d30141be99e5cd1102e7d2258d2892314cf4c110726c3", size = 4791428 },
+    { url = "https://files.pythonhosted.org/packages/29/31/c0267d03b16954a85ed6b065116b621d37f559553d9339c7dcc4943a76f1/lxml-6.0.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c907516d49f77f6cd8ead1322198bdfd902003c3c330c77a1c5f3cc32a0e4d16", size = 5678523 },
+    { url = "https://files.pythonhosted.org/packages/5c/f7/5495829a864bc5f8b0798d2b52a807c89966523140f3d6fa3a58ab6720ea/lxml-6.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:36531f81c8214e293097cd2b7873f178997dae33d3667caaae8bdfb9666b76c0", size = 5281290 },
+    { url = "https://files.pythonhosted.org/packages/79/56/6b8edb79d9ed294ccc4e881f4db1023af56ba451909b9ce79f2a2cd7c532/lxml-6.0.0-cp312-cp312-win32.whl", hash = "sha256:690b20e3388a7ec98e899fd54c924e50ba6693874aa65ef9cb53de7f7de9d64a", size = 3613495 },
+    { url = "https://files.pythonhosted.org/packages/0b/1e/cc32034b40ad6af80b6fd9b66301fc0f180f300002e5c3eb5a6110a93317/lxml-6.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:310b719b695b3dd442cdfbbe64936b2f2e231bb91d998e99e6f0daf991a3eba3", size = 4014711 },
+    { url = "https://files.pythonhosted.org/packages/55/10/dc8e5290ae4c94bdc1a4c55865be7e1f31dfd857a88b21cbba68b5fea61b/lxml-6.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:8cb26f51c82d77483cdcd2b4a53cda55bbee29b3c2f3ddeb47182a2a9064e4eb", size = 3674431 },
+    { url = "https://files.pythonhosted.org/packages/79/21/6e7c060822a3c954ff085e5e1b94b4a25757c06529eac91e550f3f5cd8b8/lxml-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6da7cd4f405fd7db56e51e96bff0865b9853ae70df0e6720624049da76bde2da", size = 8414372 },
+    { url = "https://files.pythonhosted.org/packages/a4/f6/051b1607a459db670fc3a244fa4f06f101a8adf86cda263d1a56b3a4f9d5/lxml-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b34339898bb556a2351a1830f88f751679f343eabf9cf05841c95b165152c9e7", size = 4593940 },
+    { url = "https://files.pythonhosted.org/packages/8e/74/dd595d92a40bda3c687d70d4487b2c7eff93fd63b568acd64fedd2ba00fe/lxml-6.0.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:51a5e4c61a4541bd1cd3ba74766d0c9b6c12d6a1a4964ef60026832aac8e79b3", size = 5214329 },
+    { url = "https://files.pythonhosted.org/packages/52/46/3572761efc1bd45fcafb44a63b3b0feeb5b3f0066886821e94b0254f9253/lxml-6.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d18a25b19ca7307045581b18b3ec9ead2b1db5ccd8719c291f0cd0a5cec6cb81", size = 4947559 },
+    { url = "https://files.pythonhosted.org/packages/94/8a/5e40de920e67c4f2eef9151097deb9b52d86c95762d8ee238134aff2125d/lxml-6.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4f0c66df4386b75d2ab1e20a489f30dc7fd9a06a896d64980541506086be1f1", size = 5102143 },
+    { url = "https://files.pythonhosted.org/packages/7c/4b/20555bdd75d57945bdabfbc45fdb1a36a1a0ff9eae4653e951b2b79c9209/lxml-6.0.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f4b481b6cc3a897adb4279216695150bbe7a44c03daba3c894f49d2037e0a24", size = 5021931 },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/cf03b412f3763d4ca23b25e70c96a74cfece64cec3addf1c4ec639586b13/lxml-6.0.0-cp313-cp313-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a78d6c9168f5bcb20971bf3329c2b83078611fbe1f807baadc64afc70523b3a", size = 5645469 },
+    { url = "https://files.pythonhosted.org/packages/d4/dd/39c8507c16db6031f8c1ddf70ed95dbb0a6d466a40002a3522c128aba472/lxml-6.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae06fbab4f1bb7db4f7c8ca9897dc8db4447d1a2b9bee78474ad403437bcc29", size = 5247467 },
+    { url = "https://files.pythonhosted.org/packages/4d/56/732d49def0631ad633844cfb2664563c830173a98d5efd9b172e89a4800d/lxml-6.0.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:1fa377b827ca2023244a06554c6e7dc6828a10aaf74ca41965c5d8a4925aebb4", size = 4720601 },
+    { url = "https://files.pythonhosted.org/packages/8f/7f/6b956fab95fa73462bca25d1ea7fc8274ddf68fb8e60b78d56c03b65278e/lxml-6.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1676b56d48048a62ef77a250428d1f31f610763636e0784ba67a9740823988ca", size = 5060227 },
+    { url = "https://files.pythonhosted.org/packages/97/06/e851ac2924447e8b15a294855caf3d543424364a143c001014d22c8ca94c/lxml-6.0.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0e32698462aacc5c1cf6bdfebc9c781821b7e74c79f13e5ffc8bfe27c42b1abf", size = 4790637 },
+    { url = "https://files.pythonhosted.org/packages/06/d4/fd216f3cd6625022c25b336c7570d11f4a43adbaf0a56106d3d496f727a7/lxml-6.0.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4d6036c3a296707357efb375cfc24bb64cd955b9ec731abf11ebb1e40063949f", size = 5662049 },
+    { url = "https://files.pythonhosted.org/packages/52/03/0e764ce00b95e008d76b99d432f1807f3574fb2945b496a17807a1645dbd/lxml-6.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7488a43033c958637b1a08cddc9188eb06d3ad36582cebc7d4815980b47e27ef", size = 5272430 },
+    { url = "https://files.pythonhosted.org/packages/5f/01/d48cc141bc47bc1644d20fe97bbd5e8afb30415ec94f146f2f76d0d9d098/lxml-6.0.0-cp313-cp313-win32.whl", hash = "sha256:5fcd7d3b1d8ecb91445bd71b9c88bdbeae528fefee4f379895becfc72298d181", size = 3612896 },
+    { url = "https://files.pythonhosted.org/packages/f4/87/6456b9541d186ee7d4cb53bf1b9a0d7f3b1068532676940fdd594ac90865/lxml-6.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:2f34687222b78fff795feeb799a7d44eca2477c3d9d3a46ce17d51a4f383e32e", size = 4013132 },
+    { url = "https://files.pythonhosted.org/packages/b7/42/85b3aa8f06ca0d24962f8100f001828e1f1f1a38c954c16e71154ed7d53a/lxml-6.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:21db1ec5525780fd07251636eb5f7acb84003e9382c72c18c542a87c416ade03", size = 3672642 },
+    { url = "https://files.pythonhosted.org/packages/66/e1/2c22a3cff9e16e1d717014a1e6ec2bf671bf56ea8716bb64466fcf820247/lxml-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:dbdd7679a6f4f08152818043dbb39491d1af3332128b3752c3ec5cebc0011a72", size = 3898804 },
+    { url = "https://files.pythonhosted.org/packages/2b/3a/d68cbcb4393a2a0a867528741fafb7ce92dac5c9f4a1680df98e5e53e8f5/lxml-6.0.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:40442e2a4456e9910875ac12951476d36c0870dcb38a68719f8c4686609897c4", size = 4216406 },
+    { url = "https://files.pythonhosted.org/packages/15/8f/d9bfb13dff715ee3b2a1ec2f4a021347ea3caf9aba93dea0cfe54c01969b/lxml-6.0.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db0efd6bae1c4730b9c863fc4f5f3c0fa3e8f05cae2c44ae141cb9dfc7d091dc", size = 4326455 },
+    { url = "https://files.pythonhosted.org/packages/01/8b/fde194529ee8a27e6f5966d7eef05fa16f0567e4a8e8abc3b855ef6b3400/lxml-6.0.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ab542c91f5a47aaa58abdd8ea84b498e8e49fe4b883d67800017757a3eb78e8", size = 4268788 },
+    { url = "https://files.pythonhosted.org/packages/99/a8/3b8e2581b4f8370fc9e8dc343af4abdfadd9b9229970fc71e67bd31c7df1/lxml-6.0.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:013090383863b72c62a702d07678b658fa2567aa58d373d963cca245b017e065", size = 4411394 },
+    { url = "https://files.pythonhosted.org/packages/e7/a5/899a4719e02ff4383f3f96e5d1878f882f734377f10dfb69e73b5f223e44/lxml-6.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c86df1c9af35d903d2b52d22ea3e66db8058d21dc0f59842ca5deb0595921141", size = 3517946 },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/b6/466e71db127950fb8d172026a8f0a9f0dc6f64c8e78e2ca79f252e5790b8/lxml_html_clean-0.4.2.tar.gz", hash = "sha256:91291e7b5db95430abf461bc53440964d58e06cc468950f9e47db64976cebcb3", size = 21622 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/0b/942cb7278d6caad79343ad2ddd636ed204a47909b969d19114a3097f5aa3/lxml_html_clean-0.4.2-py3-none-any.whl", hash = "sha256:74ccfba277adcfea87a1e9294f47dd86b05d65b4da7c5b07966e3d5f3be8a505", size = 14184 },
 ]
 
 [[package]]
@@ -847,6 +1389,108 @@ wheels = [
 ]
 
 [[package]]
+name = "multidict"
+version = "6.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/2c/5dad12e82fbdf7470f29bff2171484bf07cb3b16ada60a6589af8f376440/multidict-6.6.3.tar.gz", hash = "sha256:798a9eb12dab0a6c2e29c1de6f3468af5cb2da6053a20dfa3344907eed0937cc", size = 101006 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/67/414933982bce2efce7cbcb3169eaaf901e0f25baec69432b4874dfb1f297/multidict-6.6.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a2be5b7b35271f7fff1397204ba6708365e3d773579fe2a30625e16c4b4ce817", size = 77017 },
+    { url = "https://files.pythonhosted.org/packages/8a/fe/d8a3ee1fad37dc2ef4f75488b0d9d4f25bf204aad8306cbab63d97bff64a/multidict-6.6.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:12f4581d2930840295c461764b9a65732ec01250b46c6b2c510d7ee68872b140", size = 44897 },
+    { url = "https://files.pythonhosted.org/packages/1f/e0/265d89af8c98240265d82b8cbcf35897f83b76cd59ee3ab3879050fd8c45/multidict-6.6.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dd7793bab517e706c9ed9d7310b06c8672fd0aeee5781bfad612f56b8e0f7d14", size = 44574 },
+    { url = "https://files.pythonhosted.org/packages/e6/05/6b759379f7e8e04ccc97cfb2a5dcc5cdbd44a97f072b2272dc51281e6a40/multidict-6.6.3-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:72d8815f2cd3cf3df0f83cac3f3ef801d908b2d90409ae28102e0553af85545a", size = 225729 },
+    { url = "https://files.pythonhosted.org/packages/4e/f5/8d5a15488edd9a91fa4aad97228d785df208ed6298580883aa3d9def1959/multidict-6.6.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:531e331a2ee53543ab32b16334e2deb26f4e6b9b28e41f8e0c87e99a6c8e2d69", size = 242515 },
+    { url = "https://files.pythonhosted.org/packages/6e/b5/a8f317d47d0ac5bb746d6d8325885c8967c2a8ce0bb57be5399e3642cccb/multidict-6.6.3-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:42ca5aa9329a63be8dc49040f63817d1ac980e02eeddba763a9ae5b4027b9c9c", size = 222224 },
+    { url = "https://files.pythonhosted.org/packages/76/88/18b2a0d5e80515fa22716556061189c2853ecf2aa2133081ebbe85ebea38/multidict-6.6.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:208b9b9757060b9faa6f11ab4bc52846e4f3c2fb8b14d5680c8aac80af3dc751", size = 253124 },
+    { url = "https://files.pythonhosted.org/packages/62/bf/ebfcfd6b55a1b05ef16d0775ae34c0fe15e8dab570d69ca9941073b969e7/multidict-6.6.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:acf6b97bd0884891af6a8b43d0f586ab2fcf8e717cbd47ab4bdddc09e20652d8", size = 251529 },
+    { url = "https://files.pythonhosted.org/packages/44/11/780615a98fd3775fc309d0234d563941af69ade2df0bb82c91dda6ddaea1/multidict-6.6.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:68e9e12ed00e2089725669bdc88602b0b6f8d23c0c95e52b95f0bc69f7fe9b55", size = 241627 },
+    { url = "https://files.pythonhosted.org/packages/28/3d/35f33045e21034b388686213752cabc3a1b9d03e20969e6fa8f1b1d82db1/multidict-6.6.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:05db2f66c9addb10cfa226e1acb363450fab2ff8a6df73c622fefe2f5af6d4e7", size = 239351 },
+    { url = "https://files.pythonhosted.org/packages/6e/cc/ff84c03b95b430015d2166d9aae775a3985d757b94f6635010d0038d9241/multidict-6.6.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:0db58da8eafb514db832a1b44f8fa7906fdd102f7d982025f816a93ba45e3dcb", size = 233429 },
+    { url = "https://files.pythonhosted.org/packages/2e/f0/8cd49a0b37bdea673a4b793c2093f2f4ba8e7c9d6d7c9bd672fd6d38cd11/multidict-6.6.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:14117a41c8fdb3ee19c743b1c027da0736fdb79584d61a766da53d399b71176c", size = 243094 },
+    { url = "https://files.pythonhosted.org/packages/96/19/5d9a0cfdafe65d82b616a45ae950975820289069f885328e8185e64283c2/multidict-6.6.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:877443eaaabcd0b74ff32ebeed6f6176c71850feb7d6a1d2db65945256ea535c", size = 248957 },
+    { url = "https://files.pythonhosted.org/packages/e6/dc/c90066151da87d1e489f147b9b4327927241e65f1876702fafec6729c014/multidict-6.6.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:70b72e749a4f6e7ed8fb334fa8d8496384840319512746a5f42fa0aec79f4d61", size = 243590 },
+    { url = "https://files.pythonhosted.org/packages/ec/39/458afb0cccbb0ee9164365273be3e039efddcfcb94ef35924b7dbdb05db0/multidict-6.6.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:43571f785b86afd02b3855c5ac8e86ec921b760298d6f82ff2a61daf5a35330b", size = 237487 },
+    { url = "https://files.pythonhosted.org/packages/35/38/0016adac3990426610a081787011177e661875546b434f50a26319dc8372/multidict-6.6.3-cp310-cp310-win32.whl", hash = "sha256:20c5a0c3c13a15fd5ea86c42311859f970070e4e24de5a550e99d7c271d76318", size = 41390 },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/17897a8f3f2c5363d969b4c635aa40375fe1f09168dc09a7826780bfb2a4/multidict-6.6.3-cp310-cp310-win_amd64.whl", hash = "sha256:ab0a34a007704c625e25a9116c6770b4d3617a071c8a7c30cd338dfbadfe6485", size = 45954 },
+    { url = "https://files.pythonhosted.org/packages/2d/5f/d4a717c1e457fe44072e33fa400d2b93eb0f2819c4d669381f925b7cba1f/multidict-6.6.3-cp310-cp310-win_arm64.whl", hash = "sha256:769841d70ca8bdd140a715746199fc6473414bd02efd678d75681d2d6a8986c5", size = 42981 },
+    { url = "https://files.pythonhosted.org/packages/08/f0/1a39863ced51f639c81a5463fbfa9eb4df59c20d1a8769ab9ef4ca57ae04/multidict-6.6.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:18f4eba0cbac3546b8ae31e0bbc55b02c801ae3cbaf80c247fcdd89b456ff58c", size = 76445 },
+    { url = "https://files.pythonhosted.org/packages/c9/0e/a7cfa451c7b0365cd844e90b41e21fab32edaa1e42fc0c9f68461ce44ed7/multidict-6.6.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef43b5dd842382329e4797c46f10748d8c2b6e0614f46b4afe4aee9ac33159df", size = 44610 },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/a14a4efc5ee748cc1904b0748be278c31b9295ce5f4d2ef66526f410b94d/multidict-6.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bd1fd5eec01494e0f2e8e446a74a85d5e49afb63d75a9934e4a5423dba21d", size = 44267 },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/410677d563c2d55e063ef74fe578f9d53fe6b0a51649597a5861f83ffa15/multidict-6.6.3-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5bd8d6f793a787153956cd35e24f60485bf0651c238e207b9a54f7458b16d539", size = 230004 },
+    { url = "https://files.pythonhosted.org/packages/fd/df/2b787f80059314a98e1ec6a4cc7576244986df3e56b3c755e6fc7c99e038/multidict-6.6.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bf99b4daf908c73856bd87ee0a2499c3c9a3d19bb04b9c6025e66af3fd07462", size = 247196 },
+    { url = "https://files.pythonhosted.org/packages/05/f2/f9117089151b9a8ab39f9019620d10d9718eec2ac89e7ca9d30f3ec78e96/multidict-6.6.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b9e59946b49dafaf990fd9c17ceafa62976e8471a14952163d10a7a630413a9", size = 225337 },
+    { url = "https://files.pythonhosted.org/packages/93/2d/7115300ec5b699faa152c56799b089a53ed69e399c3c2d528251f0aeda1a/multidict-6.6.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e2db616467070d0533832d204c54eea6836a5e628f2cb1e6dfd8cd6ba7277cb7", size = 257079 },
+    { url = "https://files.pythonhosted.org/packages/15/ea/ff4bab367623e39c20d3b07637225c7688d79e4f3cc1f3b9f89867677f9a/multidict-6.6.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7394888236621f61dcdd25189b2768ae5cc280f041029a5bcf1122ac63df79f9", size = 255461 },
+    { url = "https://files.pythonhosted.org/packages/74/07/2c9246cda322dfe08be85f1b8739646f2c4c5113a1422d7a407763422ec4/multidict-6.6.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f114d8478733ca7388e7c7e0ab34b72547476b97009d643644ac33d4d3fe1821", size = 246611 },
+    { url = "https://files.pythonhosted.org/packages/a8/62/279c13d584207d5697a752a66ffc9bb19355a95f7659140cb1b3cf82180e/multidict-6.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cdf22e4db76d323bcdc733514bf732e9fb349707c98d341d40ebcc6e9318ef3d", size = 243102 },
+    { url = "https://files.pythonhosted.org/packages/69/cc/e06636f48c6d51e724a8bc8d9e1db5f136fe1df066d7cafe37ef4000f86a/multidict-6.6.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e995a34c3d44ab511bfc11aa26869b9d66c2d8c799fa0e74b28a473a692532d6", size = 238693 },
+    { url = "https://files.pythonhosted.org/packages/89/a4/66c9d8fb9acf3b226cdd468ed009537ac65b520aebdc1703dd6908b19d33/multidict-6.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:766a4a5996f54361d8d5a9050140aa5362fe48ce51c755a50c0bc3706460c430", size = 246582 },
+    { url = "https://files.pythonhosted.org/packages/cf/01/c69e0317be556e46257826d5449feb4e6aa0d18573e567a48a2c14156f1f/multidict-6.6.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:3893a0d7d28a7fe6ca7a1f760593bc13038d1d35daf52199d431b61d2660602b", size = 253355 },
+    { url = "https://files.pythonhosted.org/packages/c0/da/9cc1da0299762d20e626fe0042e71b5694f9f72d7d3f9678397cbaa71b2b/multidict-6.6.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:934796c81ea996e61914ba58064920d6cad5d99140ac3167901eb932150e2e56", size = 247774 },
+    { url = "https://files.pythonhosted.org/packages/e6/91/b22756afec99cc31105ddd4a52f95ab32b1a4a58f4d417979c570c4a922e/multidict-6.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9ed948328aec2072bc00f05d961ceadfd3e9bfc2966c1319aeaf7b7c21219183", size = 242275 },
+    { url = "https://files.pythonhosted.org/packages/be/f1/adcc185b878036a20399d5be5228f3cbe7f823d78985d101d425af35c800/multidict-6.6.3-cp311-cp311-win32.whl", hash = "sha256:9f5b28c074c76afc3e4c610c488e3493976fe0e596dd3db6c8ddfbb0134dcac5", size = 41290 },
+    { url = "https://files.pythonhosted.org/packages/e0/d4/27652c1c6526ea6b4f5ddd397e93f4232ff5de42bea71d339bc6a6cc497f/multidict-6.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:bc7f6fbc61b1c16050a389c630da0b32fc6d4a3d191394ab78972bf5edc568c2", size = 45942 },
+    { url = "https://files.pythonhosted.org/packages/16/18/23f4932019804e56d3c2413e237f866444b774b0263bcb81df2fdecaf593/multidict-6.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:d4e47d8faffaae822fb5cba20937c048d4f734f43572e7079298a6c39fb172cb", size = 42880 },
+    { url = "https://files.pythonhosted.org/packages/0e/a0/6b57988ea102da0623ea814160ed78d45a2645e4bbb499c2896d12833a70/multidict-6.6.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:056bebbeda16b2e38642d75e9e5310c484b7c24e3841dc0fb943206a72ec89d6", size = 76514 },
+    { url = "https://files.pythonhosted.org/packages/07/7a/d1e92665b0850c6c0508f101f9cf0410c1afa24973e1115fe9c6a185ebf7/multidict-6.6.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e5f481cccb3c5c5e5de5d00b5141dc589c1047e60d07e85bbd7dea3d4580d63f", size = 45394 },
+    { url = "https://files.pythonhosted.org/packages/52/6f/dd104490e01be6ef8bf9573705d8572f8c2d2c561f06e3826b081d9e6591/multidict-6.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:10bea2ee839a759ee368b5a6e47787f399b41e70cf0c20d90dfaf4158dfb4e55", size = 43590 },
+    { url = "https://files.pythonhosted.org/packages/44/fe/06e0e01b1b0611e6581b7fd5a85b43dacc08b6cea3034f902f383b0873e5/multidict-6.6.3-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:2334cfb0fa9549d6ce2c21af2bfbcd3ac4ec3646b1b1581c88e3e2b1779ec92b", size = 237292 },
+    { url = "https://files.pythonhosted.org/packages/ce/71/4f0e558fb77696b89c233c1ee2d92f3e1d5459070a0e89153c9e9e804186/multidict-6.6.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8fee016722550a2276ca2cb5bb624480e0ed2bd49125b2b73b7010b9090e888", size = 258385 },
+    { url = "https://files.pythonhosted.org/packages/e3/25/cca0e68228addad24903801ed1ab42e21307a1b4b6dd2cf63da5d3ae082a/multidict-6.6.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5511cb35f5c50a2db21047c875eb42f308c5583edf96bd8ebf7d770a9d68f6d", size = 242328 },
+    { url = "https://files.pythonhosted.org/packages/6e/a3/46f2d420d86bbcb8fe660b26a10a219871a0fbf4d43cb846a4031533f3e0/multidict-6.6.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:712b348f7f449948e0a6c4564a21c7db965af900973a67db432d724619b3c680", size = 268057 },
+    { url = "https://files.pythonhosted.org/packages/9e/73/1c743542fe00794a2ec7466abd3f312ccb8fad8dff9f36d42e18fb1ec33e/multidict-6.6.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e4e15d2138ee2694e038e33b7c3da70e6b0ad8868b9f8094a72e1414aeda9c1a", size = 269341 },
+    { url = "https://files.pythonhosted.org/packages/a4/11/6ec9dcbe2264b92778eeb85407d1df18812248bf3506a5a1754bc035db0c/multidict-6.6.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8df25594989aebff8a130f7899fa03cbfcc5d2b5f4a461cf2518236fe6f15961", size = 256081 },
+    { url = "https://files.pythonhosted.org/packages/9b/2b/631b1e2afeb5f1696846d747d36cda075bfdc0bc7245d6ba5c319278d6c4/multidict-6.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:159ca68bfd284a8860f8d8112cf0521113bffd9c17568579e4d13d1f1dc76b65", size = 253581 },
+    { url = "https://files.pythonhosted.org/packages/bf/0e/7e3b93f79efeb6111d3bf9a1a69e555ba1d07ad1c11bceb56b7310d0d7ee/multidict-6.6.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e098c17856a8c9ade81b4810888c5ad1914099657226283cab3062c0540b0643", size = 250750 },
+    { url = "https://files.pythonhosted.org/packages/ad/9e/086846c1d6601948e7de556ee464a2d4c85e33883e749f46b9547d7b0704/multidict-6.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:67c92ed673049dec52d7ed39f8cf9ebbadf5032c774058b4406d18c8f8fe7063", size = 251548 },
+    { url = "https://files.pythonhosted.org/packages/8c/7b/86ec260118e522f1a31550e87b23542294880c97cfbf6fb18cc67b044c66/multidict-6.6.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:bd0578596e3a835ef451784053cfd327d607fc39ea1a14812139339a18a0dbc3", size = 262718 },
+    { url = "https://files.pythonhosted.org/packages/8c/bd/22ce8f47abb0be04692c9fc4638508b8340987b18691aa7775d927b73f72/multidict-6.6.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:346055630a2df2115cd23ae271910b4cae40f4e336773550dca4889b12916e75", size = 259603 },
+    { url = "https://files.pythonhosted.org/packages/07/9c/91b7ac1691be95cd1f4a26e36a74b97cda6aa9820632d31aab4410f46ebd/multidict-6.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:555ff55a359302b79de97e0468e9ee80637b0de1fce77721639f7cd9440b3a10", size = 251351 },
+    { url = "https://files.pythonhosted.org/packages/6f/5c/4d7adc739884f7a9fbe00d1eac8c034023ef8bad71f2ebe12823ca2e3649/multidict-6.6.3-cp312-cp312-win32.whl", hash = "sha256:73ab034fb8d58ff85c2bcbadc470efc3fafeea8affcf8722855fb94557f14cc5", size = 41860 },
+    { url = "https://files.pythonhosted.org/packages/6a/a3/0fbc7afdf7cb1aa12a086b02959307848eb6bcc8f66fcb66c0cb57e2a2c1/multidict-6.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:04cbcce84f63b9af41bad04a54d4cc4e60e90c35b9e6ccb130be2d75b71f8c17", size = 45982 },
+    { url = "https://files.pythonhosted.org/packages/b8/95/8c825bd70ff9b02462dc18d1295dd08d3e9e4eb66856d292ffa62cfe1920/multidict-6.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:0f1130b896ecb52d2a1e615260f3ea2af55fa7dc3d7c3003ba0c3121a759b18b", size = 43210 },
+    { url = "https://files.pythonhosted.org/packages/52/1d/0bebcbbb4f000751fbd09957257903d6e002943fc668d841a4cf2fb7f872/multidict-6.6.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:540d3c06d48507357a7d57721e5094b4f7093399a0106c211f33540fdc374d55", size = 75843 },
+    { url = "https://files.pythonhosted.org/packages/07/8f/cbe241b0434cfe257f65c2b1bcf9e8d5fb52bc708c5061fb29b0fed22bdf/multidict-6.6.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9c19cea2a690f04247d43f366d03e4eb110a0dc4cd1bbeee4d445435428ed35b", size = 45053 },
+    { url = "https://files.pythonhosted.org/packages/32/d2/0b3b23f9dbad5b270b22a3ac3ea73ed0a50ef2d9a390447061178ed6bdb8/multidict-6.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7af039820cfd00effec86bda5d8debef711a3e86a1d3772e85bea0f243a4bd65", size = 43273 },
+    { url = "https://files.pythonhosted.org/packages/fd/fe/6eb68927e823999e3683bc49678eb20374ba9615097d085298fd5b386564/multidict-6.6.3-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:500b84f51654fdc3944e936f2922114349bf8fdcac77c3092b03449f0e5bc2b3", size = 237124 },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/320d8507e7726c460cb77117848b3834ea0d59e769f36fdae495f7669929/multidict-6.6.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3fc723ab8a5c5ed6c50418e9bfcd8e6dceba6c271cee6728a10a4ed8561520c", size = 256892 },
+    { url = "https://files.pythonhosted.org/packages/76/60/38ee422db515ac69834e60142a1a69111ac96026e76e8e9aa347fd2e4591/multidict-6.6.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:94c47ea3ade005b5976789baaed66d4de4480d0a0bf31cef6edaa41c1e7b56a6", size = 240547 },
+    { url = "https://files.pythonhosted.org/packages/27/fb/905224fde2dff042b030c27ad95a7ae744325cf54b890b443d30a789b80e/multidict-6.6.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dbc7cf464cc6d67e83e136c9f55726da3a30176f020a36ead246eceed87f1cd8", size = 266223 },
+    { url = "https://files.pythonhosted.org/packages/76/35/dc38ab361051beae08d1a53965e3e1a418752fc5be4d3fb983c5582d8784/multidict-6.6.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:900eb9f9da25ada070f8ee4a23f884e0ee66fe4e1a38c3af644256a508ad81ca", size = 267262 },
+    { url = "https://files.pythonhosted.org/packages/1f/a3/0a485b7f36e422421b17e2bbb5a81c1af10eac1d4476f2ff92927c730479/multidict-6.6.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c6df517cf177da5d47ab15407143a89cd1a23f8b335f3a28d57e8b0a3dbb884", size = 254345 },
+    { url = "https://files.pythonhosted.org/packages/b4/59/bcdd52c1dab7c0e0d75ff19cac751fbd5f850d1fc39172ce809a74aa9ea4/multidict-6.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ef421045f13879e21c994b36e728d8e7d126c91a64b9185810ab51d474f27e7", size = 252248 },
+    { url = "https://files.pythonhosted.org/packages/bb/a4/2d96aaa6eae8067ce108d4acee6f45ced5728beda55c0f02ae1072c730d1/multidict-6.6.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:6c1e61bb4f80895c081790b6b09fa49e13566df8fbff817da3f85b3a8192e36b", size = 250115 },
+    { url = "https://files.pythonhosted.org/packages/25/d2/ed9f847fa5c7d0677d4f02ea2c163d5e48573de3f57bacf5670e43a5ffaa/multidict-6.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e5e8523bb12d7623cd8300dbd91b9e439a46a028cd078ca695eb66ba31adee3c", size = 249649 },
+    { url = "https://files.pythonhosted.org/packages/1f/af/9155850372563fc550803d3f25373308aa70f59b52cff25854086ecb4a79/multidict-6.6.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ef58340cc896219e4e653dade08fea5c55c6df41bcc68122e3be3e9d873d9a7b", size = 261203 },
+    { url = "https://files.pythonhosted.org/packages/36/2f/c6a728f699896252cf309769089568a33c6439626648843f78743660709d/multidict-6.6.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc9dc435ec8699e7b602b94fe0cd4703e69273a01cbc34409af29e7820f777f1", size = 258051 },
+    { url = "https://files.pythonhosted.org/packages/d0/60/689880776d6b18fa2b70f6cc74ff87dd6c6b9b47bd9cf74c16fecfaa6ad9/multidict-6.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9e864486ef4ab07db5e9cb997bad2b681514158d6954dd1958dfb163b83d53e6", size = 249601 },
+    { url = "https://files.pythonhosted.org/packages/75/5e/325b11f2222a549019cf2ef879c1f81f94a0d40ace3ef55cf529915ba6cc/multidict-6.6.3-cp313-cp313-win32.whl", hash = "sha256:5633a82fba8e841bc5c5c06b16e21529573cd654f67fd833650a215520a6210e", size = 41683 },
+    { url = "https://files.pythonhosted.org/packages/b1/ad/cf46e73f5d6e3c775cabd2a05976547f3f18b39bee06260369a42501f053/multidict-6.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:e93089c1570a4ad54c3714a12c2cef549dc9d58e97bcded193d928649cab78e9", size = 45811 },
+    { url = "https://files.pythonhosted.org/packages/c5/c9/2e3fe950db28fb7c62e1a5f46e1e38759b072e2089209bc033c2798bb5ec/multidict-6.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:c60b401f192e79caec61f166da9c924e9f8bc65548d4246842df91651e83d600", size = 43056 },
+    { url = "https://files.pythonhosted.org/packages/3a/58/aaf8114cf34966e084a8cc9517771288adb53465188843d5a19862cb6dc3/multidict-6.6.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:02fd8f32d403a6ff13864b0851f1f523d4c988051eea0471d4f1fd8010f11134", size = 82811 },
+    { url = "https://files.pythonhosted.org/packages/71/af/5402e7b58a1f5b987a07ad98f2501fdba2a4f4b4c30cf114e3ce8db64c87/multidict-6.6.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:f3aa090106b1543f3f87b2041eef3c156c8da2aed90c63a2fbed62d875c49c37", size = 48304 },
+    { url = "https://files.pythonhosted.org/packages/39/65/ab3c8cafe21adb45b24a50266fd747147dec7847425bc2a0f6934b3ae9ce/multidict-6.6.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e924fb978615a5e33ff644cc42e6aa241effcf4f3322c09d4f8cebde95aff5f8", size = 46775 },
+    { url = "https://files.pythonhosted.org/packages/49/ba/9fcc1b332f67cc0c0c8079e263bfab6660f87fe4e28a35921771ff3eea0d/multidict-6.6.3-cp313-cp313t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:b9fe5a0e57c6dbd0e2ce81ca66272282c32cd11d31658ee9553849d91289e1c1", size = 229773 },
+    { url = "https://files.pythonhosted.org/packages/a4/14/0145a251f555f7c754ce2dcbcd012939bbd1f34f066fa5d28a50e722a054/multidict-6.6.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b24576f208793ebae00280c59927c3b7c2a3b1655e443a25f753c4611bc1c373", size = 250083 },
+    { url = "https://files.pythonhosted.org/packages/9e/d4/d5c0bd2bbb173b586c249a151a26d2fb3ec7d53c96e42091c9fef4e1f10c/multidict-6.6.3-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:135631cb6c58eac37d7ac0df380294fecdc026b28837fa07c02e459c7fb9c54e", size = 228980 },
+    { url = "https://files.pythonhosted.org/packages/21/32/c9a2d8444a50ec48c4733ccc67254100c10e1c8ae8e40c7a2d2183b59b97/multidict-6.6.3-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:274d416b0df887aef98f19f21578653982cfb8a05b4e187d4a17103322eeaf8f", size = 257776 },
+    { url = "https://files.pythonhosted.org/packages/68/d0/14fa1699f4ef629eae08ad6201c6b476098f5efb051b296f4c26be7a9fdf/multidict-6.6.3-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e252017a817fad7ce05cafbe5711ed40faeb580e63b16755a3a24e66fa1d87c0", size = 256882 },
+    { url = "https://files.pythonhosted.org/packages/da/88/84a27570fbe303c65607d517a5f147cd2fc046c2d1da02b84b17b9bdc2aa/multidict-6.6.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e4cc8d848cd4fe1cdee28c13ea79ab0ed37fc2e89dd77bac86a2e7959a8c3bc", size = 247816 },
+    { url = "https://files.pythonhosted.org/packages/1c/60/dca352a0c999ce96a5d8b8ee0b2b9f729dcad2e0b0c195f8286269a2074c/multidict-6.6.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9e236a7094b9c4c1b7585f6b9cca34b9d833cf079f7e4c49e6a4a6ec9bfdc68f", size = 245341 },
+    { url = "https://files.pythonhosted.org/packages/50/ef/433fa3ed06028f03946f3993223dada70fb700f763f70c00079533c34578/multidict-6.6.3-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:e0cb0ab69915c55627c933f0b555a943d98ba71b4d1c57bc0d0a66e2567c7471", size = 235854 },
+    { url = "https://files.pythonhosted.org/packages/1b/1f/487612ab56fbe35715320905215a57fede20de7db40a261759690dc80471/multidict-6.6.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:81ef2f64593aba09c5212a3d0f8c906a0d38d710a011f2f42759704d4557d3f2", size = 243432 },
+    { url = "https://files.pythonhosted.org/packages/da/6f/ce8b79de16cd885c6f9052c96a3671373d00c59b3ee635ea93e6e81b8ccf/multidict-6.6.3-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:b9cbc60010de3562545fa198bfc6d3825df430ea96d2cc509c39bd71e2e7d648", size = 252731 },
+    { url = "https://files.pythonhosted.org/packages/bb/fe/a2514a6aba78e5abefa1624ca85ae18f542d95ac5cde2e3815a9fbf369aa/multidict-6.6.3-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70d974eaaa37211390cd02ef93b7e938de564bbffa866f0b08d07e5e65da783d", size = 247086 },
+    { url = "https://files.pythonhosted.org/packages/8c/22/b788718d63bb3cce752d107a57c85fcd1a212c6c778628567c9713f9345a/multidict-6.6.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3713303e4a6663c6d01d648a68f2848701001f3390a030edaaf3fc949c90bf7c", size = 243338 },
+    { url = "https://files.pythonhosted.org/packages/22/d6/fdb3d0670819f2228f3f7d9af613d5e652c15d170c83e5f1c94fbc55a25b/multidict-6.6.3-cp313-cp313t-win32.whl", hash = "sha256:639ecc9fe7cd73f2495f62c213e964843826f44505a3e5d82805aa85cac6f89e", size = 47812 },
+    { url = "https://files.pythonhosted.org/packages/b6/d6/a9d2c808f2c489ad199723197419207ecbfbc1776f6e155e1ecea9c883aa/multidict-6.6.3-cp313-cp313t-win_amd64.whl", hash = "sha256:9f97e181f344a0ef3881b573d31de8542cc0dbc559ec68c8f8b5ce2c2e91646d", size = 53011 },
+    { url = "https://files.pythonhosted.org/packages/f2/40/b68001cba8188dd267590a111f9661b6256debc327137667e832bf5d66e8/multidict-6.6.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ce8b7693da41a3c4fde5871c738a81490cea5496c671d74374c8ab889e1834fb", size = 45254 },
+    { url = "https://files.pythonhosted.org/packages/d8/30/9aec301e9772b098c1f5c0ca0279237c9766d94b97802e9888010c64b0ed/multidict-6.6.3-py3-none-any.whl", hash = "sha256:8db10f29c7541fc5da4defd8cd697e1ca429db743fa716325f236079b96f775a", size = 12313 },
+]
+
+[[package]]
 name = "mypy"
 version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -892,6 +1536,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
+]
+
+[[package]]
+name = "narwhals"
+version = "1.46.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/7f/dd8c5f7978c3136de4d660877a5279e4688ad0c56dbc15ee003c2fe981cd/narwhals-1.46.0.tar.gz", hash = "sha256:fd7e53860b233c2b5566d8b4e1b3e8e9c01b5a87649a9f9a322742000f207a60", size = 512060 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/64/c46ba7517d90e330c4f35af1256d4b12ba037e2ef17d4aa4d4f11b4a143d/narwhals-1.46.0-py3-none-any.whl", hash = "sha256:f15d2255695d7e99f624f76aa5b765eb3fff8a509d3215049707af3a3feebc90", size = 373394 },
 ]
 
 [[package]]
@@ -995,6 +1648,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/d7/e91c6a9cf71726420cddf539852ee4c29176ebb716a702d9118d0409fd8e/openai-1.93.0.tar.gz", hash = "sha256:988f31ade95e1ff0585af11cc5a64510225e4f5cd392698c675d0a9265b8e337", size = 486573 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/46/a10d9df4673df56f71201d129ba1cb19eaff3366d08c8664d61a7df52e65/openai-1.93.0-py3-none-any.whl", hash = "sha256:3d746fe5498f0dd72e0d9ab706f26c91c0f646bf7459e5629af8ba7c9dbdf090", size = 755038 },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910 },
 ]
 
 [[package]]
@@ -1110,6 +1775,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/6f/75aa71f8a14267117adeeed5d21b204770189c0a0025acbdc03c337b28fc/pandas-2.3.1.tar.gz", hash = "sha256:0a95b9ac964fe83ce317827f80304d37388ea77616b1425f0ae41c9d2d0d7bb2", size = 4487493 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ca/aa97b47287221fa37a49634532e520300088e290b20d690b21ce3e448143/pandas-2.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:22c2e866f7209ebc3a8f08d75766566aae02bcc91d196935a1d9e59c7b990ac9", size = 11542731 },
+    { url = "https://files.pythonhosted.org/packages/80/bf/7938dddc5f01e18e573dcfb0f1b8c9357d9b5fa6ffdee6e605b92efbdff2/pandas-2.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3583d348546201aff730c8c47e49bc159833f971c2899d6097bce68b9112a4f1", size = 10790031 },
+    { url = "https://files.pythonhosted.org/packages/ee/2f/9af748366763b2a494fed477f88051dbf06f56053d5c00eba652697e3f94/pandas-2.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f951fbb702dacd390561e0ea45cdd8ecfa7fb56935eb3dd78e306c19104b9b0", size = 11724083 },
+    { url = "https://files.pythonhosted.org/packages/2c/95/79ab37aa4c25d1e7df953dde407bb9c3e4ae47d154bc0dd1692f3a6dcf8c/pandas-2.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd05b72ec02ebfb993569b4931b2e16fbb4d6ad6ce80224a3ee838387d83a191", size = 12342360 },
+    { url = "https://files.pythonhosted.org/packages/75/a7/d65e5d8665c12c3c6ff5edd9709d5836ec9b6f80071b7f4a718c6106e86e/pandas-2.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1b916a627919a247d865aed068eb65eb91a344b13f5b57ab9f610b7716c92de1", size = 13202098 },
+    { url = "https://files.pythonhosted.org/packages/65/f3/4c1dbd754dbaa79dbf8b537800cb2fa1a6e534764fef50ab1f7533226c5c/pandas-2.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fe67dc676818c186d5a3d5425250e40f179c2a89145df477dd82945eaea89e97", size = 13837228 },
+    { url = "https://files.pythonhosted.org/packages/3f/d6/d7f5777162aa9b48ec3910bca5a58c9b5927cfd9cfde3aa64322f5ba4b9f/pandas-2.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:2eb789ae0274672acbd3c575b0598d213345660120a257b47b5dafdc618aec83", size = 11336561 },
+    { url = "https://files.pythonhosted.org/packages/76/1c/ccf70029e927e473a4476c00e0d5b32e623bff27f0402d0a92b7fc29bb9f/pandas-2.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2b0540963d83431f5ce8870ea02a7430adca100cec8a050f0811f8e31035541b", size = 11566608 },
+    { url = "https://files.pythonhosted.org/packages/ec/d3/3c37cb724d76a841f14b8f5fe57e5e3645207cc67370e4f84717e8bb7657/pandas-2.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fe7317f578c6a153912bd2292f02e40c1d8f253e93c599e82620c7f69755c74f", size = 10823181 },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/367c98854a1251940edf54a4df0826dcacfb987f9068abf3e3064081a382/pandas-2.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6723a27ad7b244c0c79d8e7007092d7c8f0f11305770e2f4cd778b3ad5f9f85", size = 11793570 },
+    { url = "https://files.pythonhosted.org/packages/07/5f/63760ff107bcf5146eee41b38b3985f9055e710a72fdd637b791dea3495c/pandas-2.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3462c3735fe19f2638f2c3a40bd94ec2dc5ba13abbb032dd2fa1f540a075509d", size = 12378887 },
+    { url = "https://files.pythonhosted.org/packages/15/53/f31a9b4dfe73fe4711c3a609bd8e60238022f48eacedc257cd13ae9327a7/pandas-2.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:98bcc8b5bf7afed22cc753a28bc4d9e26e078e777066bc53fac7904ddef9a678", size = 13230957 },
+    { url = "https://files.pythonhosted.org/packages/e0/94/6fce6bf85b5056d065e0a7933cba2616dcb48596f7ba3c6341ec4bcc529d/pandas-2.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d544806b485ddf29e52d75b1f559142514e60ef58a832f74fb38e48d757b299", size = 13883883 },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/bdcb1ed8fccb63d04bdb7635161d0ec26596d92c9d7a6cce964e7876b6c1/pandas-2.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:b3cd4273d3cb3707b6fffd217204c52ed92859533e31dc03b7c5008aa933aaab", size = 11340212 },
+    { url = "https://files.pythonhosted.org/packages/46/de/b8445e0f5d217a99fe0eeb2f4988070908979bec3587c0633e5428ab596c/pandas-2.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:689968e841136f9e542020698ee1c4fbe9caa2ed2213ae2388dc7b81721510d3", size = 11588172 },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/801cdb3564e65a5ac041ab99ea6f1d802a6c325bb6e58c79c06a3f1cd010/pandas-2.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:025e92411c16cbe5bb2a4abc99732a6b132f439b8aab23a59fa593eb00704232", size = 10717365 },
+    { url = "https://files.pythonhosted.org/packages/51/a5/c76a8311833c24ae61a376dbf360eb1b1c9247a5d9c1e8b356563b31b80c/pandas-2.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b7ff55f31c4fcb3e316e8f7fa194566b286d6ac430afec0d461163312c5841e", size = 11280411 },
+    { url = "https://files.pythonhosted.org/packages/da/01/e383018feba0a1ead6cf5fe8728e5d767fee02f06a3d800e82c489e5daaf/pandas-2.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dcb79bf373a47d2a40cf7232928eb7540155abbc460925c2c96d2d30b006eb4", size = 11988013 },
+    { url = "https://files.pythonhosted.org/packages/5b/14/cec7760d7c9507f11c97d64f29022e12a6cc4fc03ac694535e89f88ad2ec/pandas-2.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:56a342b231e8862c96bdb6ab97170e203ce511f4d0429589c8ede1ee8ece48b8", size = 12767210 },
+    { url = "https://files.pythonhosted.org/packages/50/b9/6e2d2c6728ed29fb3d4d4d302504fb66f1a543e37eb2e43f352a86365cdf/pandas-2.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ca7ed14832bce68baef331f4d7f294411bed8efd032f8109d690df45e00c4679", size = 13440571 },
+    { url = "https://files.pythonhosted.org/packages/80/a5/3a92893e7399a691bad7664d977cb5e7c81cf666c81f89ea76ba2bff483d/pandas-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ac942bfd0aca577bef61f2bc8da8147c4ef6879965ef883d8e8d5d2dc3e744b8", size = 10987601 },
+    { url = "https://files.pythonhosted.org/packages/32/ed/ff0a67a2c5505e1854e6715586ac6693dd860fbf52ef9f81edee200266e7/pandas-2.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9026bd4a80108fac2239294a15ef9003c4ee191a0f64b90f170b40cfb7cf2d22", size = 11531393 },
+    { url = "https://files.pythonhosted.org/packages/c7/db/d8f24a7cc9fb0972adab0cc80b6817e8bef888cfd0024eeb5a21c0bb5c4a/pandas-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6de8547d4fdb12421e2d047a2c446c623ff4c11f47fddb6b9169eb98ffba485a", size = 10668750 },
+    { url = "https://files.pythonhosted.org/packages/0f/b0/80f6ec783313f1e2356b28b4fd8d2148c378370045da918c73145e6aab50/pandas-2.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:782647ddc63c83133b2506912cc6b108140a38a37292102aaa19c81c83db2928", size = 11342004 },
+    { url = "https://files.pythonhosted.org/packages/e9/e2/20a317688435470872885e7fc8f95109ae9683dec7c50be29b56911515a5/pandas-2.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ba6aff74075311fc88504b1db890187a3cd0f887a5b10f5525f8e2ef55bfdb9", size = 12050869 },
+    { url = "https://files.pythonhosted.org/packages/55/79/20d746b0a96c67203a5bee5fb4e00ac49c3e8009a39e1f78de264ecc5729/pandas-2.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e5635178b387bd2ba4ac040f82bc2ef6e6b500483975c4ebacd34bec945fda12", size = 12750218 },
+    { url = "https://files.pythonhosted.org/packages/7c/0f/145c8b41e48dbf03dd18fdd7f24f8ba95b8254a97a3379048378f33e7838/pandas-2.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f3bf5ec947526106399a9e1d26d40ee2b259c66422efdf4de63c848492d91bb", size = 13416763 },
+    { url = "https://files.pythonhosted.org/packages/b2/c0/54415af59db5cdd86a3d3bf79863e8cc3fa9ed265f0745254061ac09d5f2/pandas-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:1c78cf43c8fde236342a1cb2c34bcff89564a7bfed7e474ed2fffa6aed03a956", size = 10987482 },
+    { url = "https://files.pythonhosted.org/packages/48/64/2fd2e400073a1230e13b8cd604c9bc95d9e3b962e5d44088ead2e8f0cfec/pandas-2.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8dfc17328e8da77be3cf9f47509e5637ba8f137148ed0e9b5241e1baf526e20a", size = 12029159 },
+    { url = "https://files.pythonhosted.org/packages/d8/0a/d84fd79b0293b7ef88c760d7dca69828d867c89b6d9bc52d6a27e4d87316/pandas-2.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ec6c851509364c59a5344458ab935e6451b31b818be467eb24b0fe89bd05b6b9", size = 11393287 },
+    { url = "https://files.pythonhosted.org/packages/50/ae/ff885d2b6e88f3c7520bb74ba319268b42f05d7e583b5dded9837da2723f/pandas-2.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:911580460fc4884d9b05254b38a6bfadddfcc6aaef856fb5859e7ca202e45275", size = 11309381 },
+    { url = "https://files.pythonhosted.org/packages/85/86/1fa345fc17caf5d7780d2699985c03dbe186c68fee00b526813939062bb0/pandas-2.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f4d6feeba91744872a600e6edbbd5b033005b431d5ae8379abee5bcfa479fab", size = 11883998 },
+    { url = "https://files.pythonhosted.org/packages/81/aa/e58541a49b5e6310d89474333e994ee57fea97c8aaa8fc7f00b873059bbf/pandas-2.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fe37e757f462d31a9cd7580236a82f353f5713a80e059a29753cf938c6775d96", size = 12704705 },
+    { url = "https://files.pythonhosted.org/packages/d5/f9/07086f5b0f2a19872554abeea7658200824f5835c58a106fa8f2ae96a46c/pandas-2.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5db9637dbc24b631ff3707269ae4559bce4b7fd75c1c4d7e13f40edc42df4444", size = 13189044 },
 ]
 
 [[package]]
@@ -1273,17 +1986,22 @@ wheels = [
 
 [[package]]
 name = "podcast-creator"
-version = "0.2.6"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },
     { name = "click" },
+    { name = "content-core" },
     { name = "esperanto" },
     { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "loguru" },
     { name = "moviepy" },
+    { name = "nest-asyncio" },
+    { name = "pydub" },
     { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "streamlit" },
     { name = "tiktoken" },
 ]
 
@@ -1301,12 +2019,17 @@ dev = [
 requires-dist = [
     { name = "ai-prompter", specifier = ">=0.3.1" },
     { name = "click", specifier = ">=8.0.0" },
+    { name = "content-core", specifier = ">=1.2.3" },
     { name = "esperanto", specifier = ">=2.3.2" },
     { name = "langchain-openai", specifier = ">=0.3.27" },
     { name = "langgraph", specifier = ">=0.2.74" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "moviepy", specifier = ">=2.2.1" },
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
+    { name = "pydub", specifier = ">=0.25.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "requests", specifier = ">=2.32.4" },
+    { name = "streamlit", specifier = ">=1.46.1" },
     { name = "tiktoken", specifier = ">=0.9.0" },
 ]
 
@@ -1345,6 +2068,109 @@ wheels = [
 ]
 
 [[package]]
+name = "propcache"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/16/43264e4a779dd8588c21a70f0709665ee8f611211bdd2c87d952cfa7c776/propcache-0.3.2.tar.gz", hash = "sha256:20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168", size = 44139 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/14/510deed325e262afeb8b360043c5d7c960da7d3ecd6d6f9496c9c56dc7f4/propcache-0.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:22d9962a358aedbb7a2e36187ff273adeaab9743373a272976d2e348d08c7770", size = 73178 },
+    { url = "https://files.pythonhosted.org/packages/cd/4e/ad52a7925ff01c1325653a730c7ec3175a23f948f08626a534133427dcff/propcache-0.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0d0fda578d1dc3f77b6b5a5dce3b9ad69a8250a891760a548df850a5e8da87f3", size = 43133 },
+    { url = "https://files.pythonhosted.org/packages/63/7c/e9399ba5da7780871db4eac178e9c2e204c23dd3e7d32df202092a1ed400/propcache-0.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3def3da3ac3ce41562d85db655d18ebac740cb3fa4367f11a52b3da9d03a5cc3", size = 43039 },
+    { url = "https://files.pythonhosted.org/packages/22/e1/58da211eb8fdc6fc854002387d38f415a6ca5f5c67c1315b204a5d3e9d7a/propcache-0.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9bec58347a5a6cebf239daba9bda37dffec5b8d2ce004d9fe4edef3d2815137e", size = 201903 },
+    { url = "https://files.pythonhosted.org/packages/c4/0a/550ea0f52aac455cb90111c8bab995208443e46d925e51e2f6ebdf869525/propcache-0.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55ffda449a507e9fbd4aca1a7d9aa6753b07d6166140e5a18d2ac9bc49eac220", size = 213362 },
+    { url = "https://files.pythonhosted.org/packages/5a/af/9893b7d878deda9bb69fcf54600b247fba7317761b7db11fede6e0f28bd0/propcache-0.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:64a67fb39229a8a8491dd42f864e5e263155e729c2e7ff723d6e25f596b1e8cb", size = 210525 },
+    { url = "https://files.pythonhosted.org/packages/7c/bb/38fd08b278ca85cde36d848091ad2b45954bc5f15cce494bb300b9285831/propcache-0.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9da1cf97b92b51253d5b68cf5a2b9e0dafca095e36b7f2da335e27dc6172a614", size = 198283 },
+    { url = "https://files.pythonhosted.org/packages/78/8c/9fe55bd01d362bafb413dfe508c48753111a1e269737fa143ba85693592c/propcache-0.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5f559e127134b07425134b4065be45b166183fdcb433cb6c24c8e4149056ad50", size = 191872 },
+    { url = "https://files.pythonhosted.org/packages/54/14/4701c33852937a22584e08abb531d654c8bcf7948a8f87ad0a4822394147/propcache-0.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aff2e4e06435d61f11a428360a932138d0ec288b0a31dd9bd78d200bd4a2b339", size = 199452 },
+    { url = "https://files.pythonhosted.org/packages/16/44/447f2253d859602095356007657ee535e0093215ea0b3d1d6a41d16e5201/propcache-0.3.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:4927842833830942a5d0a56e6f4839bc484785b8e1ce8d287359794818633ba0", size = 191567 },
+    { url = "https://files.pythonhosted.org/packages/f2/b3/e4756258749bb2d3b46defcff606a2f47410bab82be5824a67e84015b267/propcache-0.3.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:6107ddd08b02654a30fb8ad7a132021759d750a82578b94cd55ee2772b6ebea2", size = 193015 },
+    { url = "https://files.pythonhosted.org/packages/1e/df/e6d3c7574233164b6330b9fd697beeac402afd367280e6dc377bb99b43d9/propcache-0.3.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:70bd8b9cd6b519e12859c99f3fc9a93f375ebd22a50296c3a295028bea73b9e7", size = 204660 },
+    { url = "https://files.pythonhosted.org/packages/b2/53/e4d31dd5170b4a0e2e6b730f2385a96410633b4833dc25fe5dffd1f73294/propcache-0.3.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2183111651d710d3097338dd1893fcf09c9f54e27ff1a8795495a16a469cc90b", size = 206105 },
+    { url = "https://files.pythonhosted.org/packages/7f/fe/74d54cf9fbe2a20ff786e5f7afcfde446588f0cf15fb2daacfbc267b866c/propcache-0.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fb075ad271405dcad8e2a7ffc9a750a3bf70e533bd86e89f0603e607b93aa64c", size = 196980 },
+    { url = "https://files.pythonhosted.org/packages/22/ec/c469c9d59dada8a7679625e0440b544fe72e99311a4679c279562051f6fc/propcache-0.3.2-cp310-cp310-win32.whl", hash = "sha256:404d70768080d3d3bdb41d0771037da19d8340d50b08e104ca0e7f9ce55fce70", size = 37679 },
+    { url = "https://files.pythonhosted.org/packages/38/35/07a471371ac89d418f8d0b699c75ea6dca2041fbda360823de21f6a9ce0a/propcache-0.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:7435d766f978b4ede777002e6b3b6641dd229cd1da8d3d3106a45770365f9ad9", size = 41459 },
+    { url = "https://files.pythonhosted.org/packages/80/8d/e8b436717ab9c2cfc23b116d2c297305aa4cd8339172a456d61ebf5669b8/propcache-0.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0b8d2f607bd8f80ddc04088bc2a037fdd17884a6fcadc47a96e334d72f3717be", size = 74207 },
+    { url = "https://files.pythonhosted.org/packages/d6/29/1e34000e9766d112171764b9fa3226fa0153ab565d0c242c70e9945318a7/propcache-0.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:06766d8f34733416e2e34f46fea488ad5d60726bb9481d3cddf89a6fa2d9603f", size = 43648 },
+    { url = "https://files.pythonhosted.org/packages/46/92/1ad5af0df781e76988897da39b5f086c2bf0f028b7f9bd1f409bb05b6874/propcache-0.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a2dc1f4a1df4fecf4e6f68013575ff4af84ef6f478fe5344317a65d38a8e6dc9", size = 43496 },
+    { url = "https://files.pythonhosted.org/packages/b3/ce/e96392460f9fb68461fabab3e095cb00c8ddf901205be4eae5ce246e5b7e/propcache-0.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be29c4f4810c5789cf10ddf6af80b041c724e629fa51e308a7a0fb19ed1ef7bf", size = 217288 },
+    { url = "https://files.pythonhosted.org/packages/c5/2a/866726ea345299f7ceefc861a5e782b045545ae6940851930a6adaf1fca6/propcache-0.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59d61f6970ecbd8ff2e9360304d5c8876a6abd4530cb752c06586849ac8a9dc9", size = 227456 },
+    { url = "https://files.pythonhosted.org/packages/de/03/07d992ccb6d930398689187e1b3c718339a1c06b8b145a8d9650e4726166/propcache-0.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62180e0b8dbb6b004baec00a7983e4cc52f5ada9cd11f48c3528d8cfa7b96a66", size = 225429 },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/116ba39448753b1330f48ab8ba927dcd6cf0baea8a0ccbc512dfb49ba670/propcache-0.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c144ca294a204c470f18cf4c9d78887810d04a3e2fbb30eea903575a779159df", size = 213472 },
+    { url = "https://files.pythonhosted.org/packages/a6/85/f01f5d97e54e428885a5497ccf7f54404cbb4f906688a1690cd51bf597dc/propcache-0.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5c2a784234c28854878d68978265617aa6dc0780e53d44b4d67f3651a17a9a2", size = 204480 },
+    { url = "https://files.pythonhosted.org/packages/e3/79/7bf5ab9033b8b8194cc3f7cf1aaa0e9c3256320726f64a3e1f113a812dce/propcache-0.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5745bc7acdafa978ca1642891b82c19238eadc78ba2aaa293c6863b304e552d7", size = 214530 },
+    { url = "https://files.pythonhosted.org/packages/31/0b/bd3e0c00509b609317df4a18e6b05a450ef2d9a963e1d8bc9c9415d86f30/propcache-0.3.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:c0075bf773d66fa8c9d41f66cc132ecc75e5bb9dd7cce3cfd14adc5ca184cb95", size = 205230 },
+    { url = "https://files.pythonhosted.org/packages/7a/23/fae0ff9b54b0de4e819bbe559508da132d5683c32d84d0dc2ccce3563ed4/propcache-0.3.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5f57aa0847730daceff0497f417c9de353c575d8da3579162cc74ac294c5369e", size = 206754 },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/ad6a3c22630aaa5f618b4dc3c3598974a72abb4c18e45a50b3cdd091eb2f/propcache-0.3.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:eef914c014bf72d18efb55619447e0aecd5fb7c2e3fa7441e2e5d6099bddff7e", size = 218430 },
+    { url = "https://files.pythonhosted.org/packages/5b/2c/ba4f1c0e8a4b4c75910742f0d333759d441f65a1c7f34683b4a74c0ee015/propcache-0.3.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2a4092e8549031e82facf3decdbc0883755d5bbcc62d3aea9d9e185549936dcf", size = 223884 },
+    { url = "https://files.pythonhosted.org/packages/88/e4/ebe30fc399e98572019eee82ad0caf512401661985cbd3da5e3140ffa1b0/propcache-0.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:85871b050f174bc0bfb437efbdb68aaf860611953ed12418e4361bc9c392749e", size = 211480 },
+    { url = "https://files.pythonhosted.org/packages/96/0a/7d5260b914e01d1d0906f7f38af101f8d8ed0dc47426219eeaf05e8ea7c2/propcache-0.3.2-cp311-cp311-win32.whl", hash = "sha256:36c8d9b673ec57900c3554264e630d45980fd302458e4ac801802a7fd2ef7897", size = 37757 },
+    { url = "https://files.pythonhosted.org/packages/e1/2d/89fe4489a884bc0da0c3278c552bd4ffe06a1ace559db5ef02ef24ab446b/propcache-0.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:e53af8cb6a781b02d2ea079b5b853ba9430fcbe18a8e3ce647d5982a3ff69f39", size = 41500 },
+    { url = "https://files.pythonhosted.org/packages/a8/42/9ca01b0a6f48e81615dca4765a8f1dd2c057e0540f6116a27dc5ee01dfb6/propcache-0.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8de106b6c84506b31c27168582cd3cb3000a6412c16df14a8628e5871ff83c10", size = 73674 },
+    { url = "https://files.pythonhosted.org/packages/af/6e/21293133beb550f9c901bbece755d582bfaf2176bee4774000bd4dd41884/propcache-0.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:28710b0d3975117239c76600ea351934ac7b5ff56e60953474342608dbbb6154", size = 43570 },
+    { url = "https://files.pythonhosted.org/packages/0c/c8/0393a0a3a2b8760eb3bde3c147f62b20044f0ddac81e9d6ed7318ec0d852/propcache-0.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce26862344bdf836650ed2487c3d724b00fbfec4233a1013f597b78c1cb73615", size = 43094 },
+    { url = "https://files.pythonhosted.org/packages/37/2c/489afe311a690399d04a3e03b069225670c1d489eb7b044a566511c1c498/propcache-0.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bca54bd347a253af2cf4544bbec232ab982f4868de0dd684246b67a51bc6b1db", size = 226958 },
+    { url = "https://files.pythonhosted.org/packages/9d/ca/63b520d2f3d418c968bf596839ae26cf7f87bead026b6192d4da6a08c467/propcache-0.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55780d5e9a2ddc59711d727226bb1ba83a22dd32f64ee15594b9392b1f544eb1", size = 234894 },
+    { url = "https://files.pythonhosted.org/packages/11/60/1d0ed6fff455a028d678df30cc28dcee7af77fa2b0e6962ce1df95c9a2a9/propcache-0.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:035e631be25d6975ed87ab23153db6a73426a48db688070d925aa27e996fe93c", size = 233672 },
+    { url = "https://files.pythonhosted.org/packages/37/7c/54fd5301ef38505ab235d98827207176a5c9b2aa61939b10a460ca53e123/propcache-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee6f22b6eaa39297c751d0e80c0d3a454f112f5c6481214fcf4c092074cecd67", size = 224395 },
+    { url = "https://files.pythonhosted.org/packages/ee/1a/89a40e0846f5de05fdc6779883bf46ba980e6df4d2ff8fb02643de126592/propcache-0.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ca3aee1aa955438c4dba34fc20a9f390e4c79967257d830f137bd5a8a32ed3b", size = 212510 },
+    { url = "https://files.pythonhosted.org/packages/5e/33/ca98368586c9566a6b8d5ef66e30484f8da84c0aac3f2d9aec6d31a11bd5/propcache-0.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7a4f30862869fa2b68380d677cc1c5fcf1e0f2b9ea0cf665812895c75d0ca3b8", size = 222949 },
+    { url = "https://files.pythonhosted.org/packages/ba/11/ace870d0aafe443b33b2f0b7efdb872b7c3abd505bfb4890716ad7865e9d/propcache-0.3.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b77ec3c257d7816d9f3700013639db7491a434644c906a2578a11daf13176251", size = 217258 },
+    { url = "https://files.pythonhosted.org/packages/5b/d2/86fd6f7adffcfc74b42c10a6b7db721d1d9ca1055c45d39a1a8f2a740a21/propcache-0.3.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cab90ac9d3f14b2d5050928483d3d3b8fb6b4018893fc75710e6aa361ecb2474", size = 213036 },
+    { url = "https://files.pythonhosted.org/packages/07/94/2d7d1e328f45ff34a0a284cf5a2847013701e24c2a53117e7c280a4316b3/propcache-0.3.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0b504d29f3c47cf6b9e936c1852246c83d450e8e063d50562115a6be6d3a2535", size = 227684 },
+    { url = "https://files.pythonhosted.org/packages/b7/05/37ae63a0087677e90b1d14710e532ff104d44bc1efa3b3970fff99b891dc/propcache-0.3.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:ce2ac2675a6aa41ddb2a0c9cbff53780a617ac3d43e620f8fd77ba1c84dcfc06", size = 234562 },
+    { url = "https://files.pythonhosted.org/packages/a4/7c/3f539fcae630408d0bd8bf3208b9a647ccad10976eda62402a80adf8fc34/propcache-0.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b4239611205294cc433845b914131b2a1f03500ff3c1ed093ed216b82621e1", size = 222142 },
+    { url = "https://files.pythonhosted.org/packages/7c/d2/34b9eac8c35f79f8a962546b3e97e9d4b990c420ee66ac8255d5d9611648/propcache-0.3.2-cp312-cp312-win32.whl", hash = "sha256:df4a81b9b53449ebc90cc4deefb052c1dd934ba85012aa912c7ea7b7e38b60c1", size = 37711 },
+    { url = "https://files.pythonhosted.org/packages/19/61/d582be5d226cf79071681d1b46b848d6cb03d7b70af7063e33a2787eaa03/propcache-0.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:7046e79b989d7fe457bb755844019e10f693752d169076138abf17f31380800c", size = 41479 },
+    { url = "https://files.pythonhosted.org/packages/dc/d1/8c747fafa558c603c4ca19d8e20b288aa0c7cda74e9402f50f31eb65267e/propcache-0.3.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca592ed634a73ca002967458187109265e980422116c0a107cf93d81f95af945", size = 71286 },
+    { url = "https://files.pythonhosted.org/packages/61/99/d606cb7986b60d89c36de8a85d58764323b3a5ff07770a99d8e993b3fa73/propcache-0.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9ecb0aad4020e275652ba3975740f241bd12a61f1a784df044cf7477a02bc252", size = 42425 },
+    { url = "https://files.pythonhosted.org/packages/8c/96/ef98f91bbb42b79e9bb82bdd348b255eb9d65f14dbbe3b1594644c4073f7/propcache-0.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7f08f1cc28bd2eade7a8a3d2954ccc673bb02062e3e7da09bc75d843386b342f", size = 41846 },
+    { url = "https://files.pythonhosted.org/packages/5b/ad/3f0f9a705fb630d175146cd7b1d2bf5555c9beaed54e94132b21aac098a6/propcache-0.3.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1a342c834734edb4be5ecb1e9fb48cb64b1e2320fccbd8c54bf8da8f2a84c33", size = 208871 },
+    { url = "https://files.pythonhosted.org/packages/3a/38/2085cda93d2c8b6ec3e92af2c89489a36a5886b712a34ab25de9fbca7992/propcache-0.3.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a544caaae1ac73f1fecfae70ded3e93728831affebd017d53449e3ac052ac1e", size = 215720 },
+    { url = "https://files.pythonhosted.org/packages/61/c1/d72ea2dc83ac7f2c8e182786ab0fc2c7bd123a1ff9b7975bee671866fe5f/propcache-0.3.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:310d11aa44635298397db47a3ebce7db99a4cc4b9bbdfcf6c98a60c8d5261cf1", size = 215203 },
+    { url = "https://files.pythonhosted.org/packages/af/81/b324c44ae60c56ef12007105f1460d5c304b0626ab0cc6b07c8f2a9aa0b8/propcache-0.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c1396592321ac83157ac03a2023aa6cc4a3cc3cfdecb71090054c09e5a7cce3", size = 206365 },
+    { url = "https://files.pythonhosted.org/packages/09/73/88549128bb89e66d2aff242488f62869014ae092db63ccea53c1cc75a81d/propcache-0.3.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cabf5b5902272565e78197edb682017d21cf3b550ba0460ee473753f28d23c1", size = 196016 },
+    { url = "https://files.pythonhosted.org/packages/b9/3f/3bdd14e737d145114a5eb83cb172903afba7242f67c5877f9909a20d948d/propcache-0.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0a2f2235ac46a7aa25bdeb03a9e7060f6ecbd213b1f9101c43b3090ffb971ef6", size = 205596 },
+    { url = "https://files.pythonhosted.org/packages/0f/ca/2f4aa819c357d3107c3763d7ef42c03980f9ed5c48c82e01e25945d437c1/propcache-0.3.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:92b69e12e34869a6970fd2f3da91669899994b47c98f5d430b781c26f1d9f387", size = 200977 },
+    { url = "https://files.pythonhosted.org/packages/cd/4a/e65276c7477533c59085251ae88505caf6831c0e85ff8b2e31ebcbb949b1/propcache-0.3.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:54e02207c79968ebbdffc169591009f4474dde3b4679e16634d34c9363ff56b4", size = 197220 },
+    { url = "https://files.pythonhosted.org/packages/7c/54/fc7152e517cf5578278b242396ce4d4b36795423988ef39bb8cd5bf274c8/propcache-0.3.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4adfb44cb588001f68c5466579d3f1157ca07f7504fc91ec87862e2b8e556b88", size = 210642 },
+    { url = "https://files.pythonhosted.org/packages/b9/80/abeb4a896d2767bf5f1ea7b92eb7be6a5330645bd7fb844049c0e4045d9d/propcache-0.3.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fd3e6019dc1261cd0291ee8919dd91fbab7b169bb76aeef6c716833a3f65d206", size = 212789 },
+    { url = "https://files.pythonhosted.org/packages/b3/db/ea12a49aa7b2b6d68a5da8293dcf50068d48d088100ac016ad92a6a780e6/propcache-0.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4c181cad81158d71c41a2bce88edce078458e2dd5ffee7eddd6b05da85079f43", size = 205880 },
+    { url = "https://files.pythonhosted.org/packages/d1/e5/9076a0bbbfb65d1198007059c65639dfd56266cf8e477a9707e4b1999ff4/propcache-0.3.2-cp313-cp313-win32.whl", hash = "sha256:8a08154613f2249519e549de2330cf8e2071c2887309a7b07fb56098f5170a02", size = 37220 },
+    { url = "https://files.pythonhosted.org/packages/d3/f5/b369e026b09a26cd77aa88d8fffd69141d2ae00a2abaaf5380d2603f4b7f/propcache-0.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:e41671f1594fc4ab0a6dec1351864713cb3a279910ae8b58f884a88a0a632c05", size = 40678 },
+    { url = "https://files.pythonhosted.org/packages/a4/3a/6ece377b55544941a08d03581c7bc400a3c8cd3c2865900a68d5de79e21f/propcache-0.3.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9a3cf035bbaf035f109987d9d55dc90e4b0e36e04bbbb95af3055ef17194057b", size = 76560 },
+    { url = "https://files.pythonhosted.org/packages/0c/da/64a2bb16418740fa634b0e9c3d29edff1db07f56d3546ca2d86ddf0305e1/propcache-0.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:156c03d07dc1323d8dacaa221fbe028c5c70d16709cdd63502778e6c3ccca1b0", size = 44676 },
+    { url = "https://files.pythonhosted.org/packages/36/7b/f025e06ea51cb72c52fb87e9b395cced02786610b60a3ed51da8af017170/propcache-0.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74413c0ba02ba86f55cf60d18daab219f7e531620c15f1e23d95563f505efe7e", size = 44701 },
+    { url = "https://files.pythonhosted.org/packages/a4/00/faa1b1b7c3b74fc277f8642f32a4c72ba1d7b2de36d7cdfb676db7f4303e/propcache-0.3.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f066b437bb3fa39c58ff97ab2ca351db465157d68ed0440abecb21715eb24b28", size = 276934 },
+    { url = "https://files.pythonhosted.org/packages/74/ab/935beb6f1756e0476a4d5938ff44bf0d13a055fed880caf93859b4f1baf4/propcache-0.3.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1304b085c83067914721e7e9d9917d41ad87696bf70f0bc7dee450e9c71ad0a", size = 278316 },
+    { url = "https://files.pythonhosted.org/packages/f8/9d/994a5c1ce4389610838d1caec74bdf0e98b306c70314d46dbe4fcf21a3e2/propcache-0.3.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ab50cef01b372763a13333b4e54021bdcb291fc9a8e2ccb9c2df98be51bcde6c", size = 282619 },
+    { url = "https://files.pythonhosted.org/packages/2b/00/a10afce3d1ed0287cef2e09506d3be9822513f2c1e96457ee369adb9a6cd/propcache-0.3.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fad3b2a085ec259ad2c2842666b2a0a49dea8463579c606426128925af1ed725", size = 265896 },
+    { url = "https://files.pythonhosted.org/packages/2e/a8/2aa6716ffa566ca57c749edb909ad27884680887d68517e4be41b02299f3/propcache-0.3.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:261fa020c1c14deafd54c76b014956e2f86991af198c51139faf41c4d5e83892", size = 252111 },
+    { url = "https://files.pythonhosted.org/packages/36/4f/345ca9183b85ac29c8694b0941f7484bf419c7f0fea2d1e386b4f7893eed/propcache-0.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:46d7f8aa79c927e5f987ee3a80205c987717d3659f035c85cf0c3680526bdb44", size = 268334 },
+    { url = "https://files.pythonhosted.org/packages/3e/ca/fcd54f78b59e3f97b3b9715501e3147f5340167733d27db423aa321e7148/propcache-0.3.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:6d8f3f0eebf73e3c0ff0e7853f68be638b4043c65a70517bb575eff54edd8dbe", size = 255026 },
+    { url = "https://files.pythonhosted.org/packages/8b/95/8e6a6bbbd78ac89c30c225210a5c687790e532ba4088afb8c0445b77ef37/propcache-0.3.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:03c89c1b14a5452cf15403e291c0ccd7751d5b9736ecb2c5bab977ad6c5bcd81", size = 250724 },
+    { url = "https://files.pythonhosted.org/packages/ee/b0/0dd03616142baba28e8b2d14ce5df6631b4673850a3d4f9c0f9dd714a404/propcache-0.3.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:0cc17efde71e12bbaad086d679ce575268d70bc123a5a71ea7ad76f70ba30bba", size = 268868 },
+    { url = "https://files.pythonhosted.org/packages/c5/98/2c12407a7e4fbacd94ddd32f3b1e3d5231e77c30ef7162b12a60e2dd5ce3/propcache-0.3.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:acdf05d00696bc0447e278bb53cb04ca72354e562cf88ea6f9107df8e7fd9770", size = 271322 },
+    { url = "https://files.pythonhosted.org/packages/35/91/9cb56efbb428b006bb85db28591e40b7736847b8331d43fe335acf95f6c8/propcache-0.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4445542398bd0b5d32df908031cb1b30d43ac848e20470a878b770ec2dcc6330", size = 265778 },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175 },
+    { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857 },
+    { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663 },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.31.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f3/b9655a711b32c19720253f6f06326faf90580834e2e83f840472d752bc8b/protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a", size = 441797 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6f/6ab8e4bf962fd5570d3deaa2d5c38f0a363f57b4501047b5ebeb83ab1125/protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9", size = 423603 },
+    { url = "https://files.pythonhosted.org/packages/44/3a/b15c4347dd4bf3a1b0ee882f384623e2063bb5cf9fa9d57990a4f7df2fb6/protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447", size = 435283 },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/b9689a2a250264a84e66c46d8862ba788ee7a641cdca39bccf64f59284b7/protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402", size = 425604 },
+    { url = "https://files.pythonhosted.org/packages/76/a1/7a5a94032c83375e4fe7e7f56e3976ea6ac90c5e85fac8576409e25c39c3/protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39", size = 322115 },
+    { url = "https://files.pythonhosted.org/packages/fa/b1/b59d405d64d31999244643d88c45c8241c58f17cc887e73bcb90602327f8/protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6", size = 321070 },
+    { url = "https://files.pythonhosted.org/packages/f7/af/ab3c51ab7507a7325e98ffe691d9495ee3d3aa5f589afad65ec920d39821/protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e", size = 168724 },
+]
+
+[[package]]
 name = "psutil"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1375,6 +2201,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842 },
+]
+
+[[package]]
+name = "pyarrow"
+version = "20.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/ee/a7810cb9f3d6e9238e61d312076a9859bf3668fd21c69744de9532383912/pyarrow-20.0.0.tar.gz", hash = "sha256:febc4a913592573c8d5805091a6c2b5064c8bd6e002131f01061797d91c783c1", size = 1125187 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/23/77094eb8ee0dbe88441689cb6afc40ac312a1e15d3a7acc0586999518222/pyarrow-20.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:c7dd06fd7d7b410ca5dc839cc9d485d2bc4ae5240851bcd45d85105cc90a47d7", size = 30832591 },
+    { url = "https://files.pythonhosted.org/packages/c3/d5/48cc573aff00d62913701d9fac478518f693b30c25f2c157550b0b2565cb/pyarrow-20.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:d5382de8dc34c943249b01c19110783d0d64b207167c728461add1ecc2db88e4", size = 32273686 },
+    { url = "https://files.pythonhosted.org/packages/37/df/4099b69a432b5cb412dd18adc2629975544d656df3d7fda6d73c5dba935d/pyarrow-20.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6415a0d0174487456ddc9beaead703d0ded5966129fa4fd3114d76b5d1c5ceae", size = 41337051 },
+    { url = "https://files.pythonhosted.org/packages/4c/27/99922a9ac1c9226f346e3a1e15e63dee6f623ed757ff2893f9d6994a69d3/pyarrow-20.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15aa1b3b2587e74328a730457068dc6c89e6dcbf438d4369f572af9d320a25ee", size = 42404659 },
+    { url = "https://files.pythonhosted.org/packages/21/d1/71d91b2791b829c9e98f1e0d85be66ed93aff399f80abb99678511847eaa/pyarrow-20.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5605919fbe67a7948c1f03b9f3727d82846c053cd2ce9303ace791855923fd20", size = 40695446 },
+    { url = "https://files.pythonhosted.org/packages/f1/ca/ae10fba419a6e94329707487835ec721f5a95f3ac9168500bcf7aa3813c7/pyarrow-20.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a5704f29a74b81673d266e5ec1fe376f060627c2e42c5c7651288ed4b0db29e9", size = 42278528 },
+    { url = "https://files.pythonhosted.org/packages/7a/a6/aba40a2bf01b5d00cf9cd16d427a5da1fad0fb69b514ce8c8292ab80e968/pyarrow-20.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:00138f79ee1b5aca81e2bdedb91e3739b987245e11fa3c826f9e57c5d102fb75", size = 42918162 },
+    { url = "https://files.pythonhosted.org/packages/93/6b/98b39650cd64f32bf2ec6d627a9bd24fcb3e4e6ea1873c5e1ea8a83b1a18/pyarrow-20.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f2d67ac28f57a362f1a2c1e6fa98bfe2f03230f7e15927aecd067433b1e70ce8", size = 44550319 },
+    { url = "https://files.pythonhosted.org/packages/ab/32/340238be1eb5037e7b5de7e640ee22334417239bc347eadefaf8c373936d/pyarrow-20.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:4a8b029a07956b8d7bd742ffca25374dd3f634b35e46cc7a7c3fa4c75b297191", size = 25770759 },
+    { url = "https://files.pythonhosted.org/packages/47/a2/b7930824181ceadd0c63c1042d01fa4ef63eee233934826a7a2a9af6e463/pyarrow-20.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:24ca380585444cb2a31324c546a9a56abbe87e26069189e14bdba19c86c049f0", size = 30856035 },
+    { url = "https://files.pythonhosted.org/packages/9b/18/c765770227d7f5bdfa8a69f64b49194352325c66a5c3bb5e332dfd5867d9/pyarrow-20.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:95b330059ddfdc591a3225f2d272123be26c8fa76e8c9ee1a77aad507361cfdb", size = 32309552 },
+    { url = "https://files.pythonhosted.org/packages/44/fb/dfb2dfdd3e488bb14f822d7335653092dde150cffc2da97de6e7500681f9/pyarrow-20.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f0fb1041267e9968c6d0d2ce3ff92e3928b243e2b6d11eeb84d9ac547308232", size = 41334704 },
+    { url = "https://files.pythonhosted.org/packages/58/0d/08a95878d38808051a953e887332d4a76bc06c6ee04351918ee1155407eb/pyarrow-20.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8ff87cc837601532cc8242d2f7e09b4e02404de1b797aee747dd4ba4bd6313f", size = 42399836 },
+    { url = "https://files.pythonhosted.org/packages/f3/cd/efa271234dfe38f0271561086eedcad7bc0f2ddd1efba423916ff0883684/pyarrow-20.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7a3a5dcf54286e6141d5114522cf31dd67a9e7c9133d150799f30ee302a7a1ab", size = 40711789 },
+    { url = "https://files.pythonhosted.org/packages/46/1f/7f02009bc7fc8955c391defee5348f510e589a020e4b40ca05edcb847854/pyarrow-20.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a6ad3e7758ecf559900261a4df985662df54fb7fdb55e8e3b3aa99b23d526b62", size = 42301124 },
+    { url = "https://files.pythonhosted.org/packages/4f/92/692c562be4504c262089e86757a9048739fe1acb4024f92d39615e7bab3f/pyarrow-20.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6bb830757103a6cb300a04610e08d9636f0cd223d32f388418ea893a3e655f1c", size = 42916060 },
+    { url = "https://files.pythonhosted.org/packages/a4/ec/9f5c7e7c828d8e0a3c7ef50ee62eca38a7de2fa6eb1b8fa43685c9414fef/pyarrow-20.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:96e37f0766ecb4514a899d9a3554fadda770fb57ddf42b63d80f14bc20aa7db3", size = 44547640 },
+    { url = "https://files.pythonhosted.org/packages/54/96/46613131b4727f10fd2ffa6d0d6f02efcc09a0e7374eff3b5771548aa95b/pyarrow-20.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:3346babb516f4b6fd790da99b98bed9708e3f02e734c84971faccb20736848dc", size = 25781491 },
+    { url = "https://files.pythonhosted.org/packages/a1/d6/0c10e0d54f6c13eb464ee9b67a68b8c71bcf2f67760ef5b6fbcddd2ab05f/pyarrow-20.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:75a51a5b0eef32727a247707d4755322cb970be7e935172b6a3a9f9ae98404ba", size = 30815067 },
+    { url = "https://files.pythonhosted.org/packages/7e/e2/04e9874abe4094a06fd8b0cbb0f1312d8dd7d707f144c2ec1e5e8f452ffa/pyarrow-20.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:211d5e84cecc640c7a3ab900f930aaff5cd2702177e0d562d426fb7c4f737781", size = 32297128 },
+    { url = "https://files.pythonhosted.org/packages/31/fd/c565e5dcc906a3b471a83273039cb75cb79aad4a2d4a12f76cc5ae90a4b8/pyarrow-20.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ba3cf4182828be7a896cbd232aa8dd6a31bd1f9e32776cc3796c012855e1199", size = 41334890 },
+    { url = "https://files.pythonhosted.org/packages/af/a9/3bdd799e2c9b20c1ea6dc6fa8e83f29480a97711cf806e823f808c2316ac/pyarrow-20.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c3a01f313ffe27ac4126f4c2e5ea0f36a5fc6ab51f8726cf41fee4b256680bd", size = 42421775 },
+    { url = "https://files.pythonhosted.org/packages/10/f7/da98ccd86354c332f593218101ae56568d5dcedb460e342000bd89c49cc1/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a2791f69ad72addd33510fec7bb14ee06c2a448e06b649e264c094c5b5f7ce28", size = 40687231 },
+    { url = "https://files.pythonhosted.org/packages/bb/1b/2168d6050e52ff1e6cefc61d600723870bf569cbf41d13db939c8cf97a16/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4250e28a22302ce8692d3a0e8ec9d9dde54ec00d237cff4dfa9c1fbf79e472a8", size = 42295639 },
+    { url = "https://files.pythonhosted.org/packages/b2/66/2d976c0c7158fd25591c8ca55aee026e6d5745a021915a1835578707feb3/pyarrow-20.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:89e030dc58fc760e4010148e6ff164d2f44441490280ef1e97a542375e41058e", size = 42908549 },
+    { url = "https://files.pythonhosted.org/packages/31/a9/dfb999c2fc6911201dcbf348247f9cc382a8990f9ab45c12eabfd7243a38/pyarrow-20.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6102b4864d77102dbbb72965618e204e550135a940c2534711d5ffa787df2a5a", size = 44557216 },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/9adee63dfa3911be2382fb4d92e4b2e7d82610f9d9f668493bebaa2af50f/pyarrow-20.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:96d6a0a37d9c98be08f5ed6a10831d88d52cac7b13f5287f1e0f625a0de8062b", size = 25660496 },
+    { url = "https://files.pythonhosted.org/packages/9b/aa/daa413b81446d20d4dad2944110dcf4cf4f4179ef7f685dd5a6d7570dc8e/pyarrow-20.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a15532e77b94c61efadde86d10957950392999503b3616b2ffcef7621a002893", size = 30798501 },
+    { url = "https://files.pythonhosted.org/packages/ff/75/2303d1caa410925de902d32ac215dc80a7ce7dd8dfe95358c165f2adf107/pyarrow-20.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:dd43f58037443af715f34f1322c782ec463a3c8a94a85fdb2d987ceb5658e061", size = 32277895 },
+    { url = "https://files.pythonhosted.org/packages/92/41/fe18c7c0b38b20811b73d1bdd54b1fccba0dab0e51d2048878042d84afa8/pyarrow-20.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa0d288143a8585806e3cc7c39566407aab646fb9ece164609dac1cfff45f6ae", size = 41327322 },
+    { url = "https://files.pythonhosted.org/packages/da/ab/7dbf3d11db67c72dbf36ae63dcbc9f30b866c153b3a22ef728523943eee6/pyarrow-20.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6953f0114f8d6f3d905d98e987d0924dabce59c3cda380bdfaa25a6201563b4", size = 42411441 },
+    { url = "https://files.pythonhosted.org/packages/90/c3/0c7da7b6dac863af75b64e2f827e4742161128c350bfe7955b426484e226/pyarrow-20.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:991f85b48a8a5e839b2128590ce07611fae48a904cae6cab1f089c5955b57eb5", size = 40677027 },
+    { url = "https://files.pythonhosted.org/packages/be/27/43a47fa0ff9053ab5203bb3faeec435d43c0d8bfa40179bfd076cdbd4e1c/pyarrow-20.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:97c8dc984ed09cb07d618d57d8d4b67a5100a30c3818c2fb0b04599f0da2de7b", size = 42281473 },
+    { url = "https://files.pythonhosted.org/packages/bc/0b/d56c63b078876da81bbb9ba695a596eabee9b085555ed12bf6eb3b7cab0e/pyarrow-20.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9b71daf534f4745818f96c214dbc1e6124d7daf059167330b610fc69b6f3d3e3", size = 42893897 },
+    { url = "https://files.pythonhosted.org/packages/92/ac/7d4bd020ba9145f354012838692d48300c1b8fe5634bfda886abcada67ed/pyarrow-20.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8b88758f9303fa5a83d6c90e176714b2fd3852e776fc2d7e42a22dd6c2fb368", size = 44543847 },
+    { url = "https://files.pythonhosted.org/packages/9d/07/290f4abf9ca702c5df7b47739c1b2c83588641ddfa2cc75e34a301d42e55/pyarrow-20.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:30b3051b7975801c1e1d387e17c588d8ab05ced9b1e14eec57915f79869b5031", size = 25653219 },
+    { url = "https://files.pythonhosted.org/packages/95/df/720bb17704b10bd69dde086e1400b8eefb8f58df3f8ac9cff6c425bf57f1/pyarrow-20.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:ca151afa4f9b7bc45bcc791eb9a89e90a9eb2772767d0b1e5389609c7d03db63", size = 30853957 },
+    { url = "https://files.pythonhosted.org/packages/d9/72/0d5f875efc31baef742ba55a00a25213a19ea64d7176e0fe001c5d8b6e9a/pyarrow-20.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:4680f01ecd86e0dd63e39eb5cd59ef9ff24a9d166db328679e36c108dc993d4c", size = 32247972 },
+    { url = "https://files.pythonhosted.org/packages/d5/bc/e48b4fa544d2eea72f7844180eb77f83f2030b84c8dad860f199f94307ed/pyarrow-20.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f4c8534e2ff059765647aa69b75d6543f9fef59e2cd4c6d18015192565d2b70", size = 41256434 },
+    { url = "https://files.pythonhosted.org/packages/c3/01/974043a29874aa2cf4f87fb07fd108828fc7362300265a2a64a94965e35b/pyarrow-20.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e1f8a47f4b4ae4c69c4d702cfbdfe4d41e18e5c7ef6f1bb1c50918c1e81c57b", size = 42353648 },
+    { url = "https://files.pythonhosted.org/packages/68/95/cc0d3634cde9ca69b0e51cbe830d8915ea32dda2157560dda27ff3b3337b/pyarrow-20.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:a1f60dc14658efaa927f8214734f6a01a806d7690be4b3232ba526836d216122", size = 40619853 },
+    { url = "https://files.pythonhosted.org/packages/29/c2/3ad40e07e96a3e74e7ed7cc8285aadfa84eb848a798c98ec0ad009eb6bcc/pyarrow-20.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:204a846dca751428991346976b914d6d2a82ae5b8316a6ed99789ebf976551e6", size = 42241743 },
+    { url = "https://files.pythonhosted.org/packages/eb/cb/65fa110b483339add6a9bc7b6373614166b14e20375d4daa73483755f830/pyarrow-20.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f3b117b922af5e4c6b9a9115825726cac7d8b1421c37c2b5e24fbacc8930612c", size = 42839441 },
+    { url = "https://files.pythonhosted.org/packages/98/7b/f30b1954589243207d7a0fbc9997401044bf9a033eec78f6cb50da3f304a/pyarrow-20.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e724a3fd23ae5b9c010e7be857f4405ed5e679db5c93e66204db1a69f733936a", size = 44503279 },
+    { url = "https://files.pythonhosted.org/packages/37/40/ad395740cd641869a13bcf60851296c89624662575621968dcfafabaa7f6/pyarrow-20.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:82f1ee5133bd8f49d31be1299dc07f585136679666b502540db854968576faf9", size = 25944982 },
 ]
 
 [[package]]
@@ -1489,12 +2368,49 @@ wheels = [
 ]
 
 [[package]]
+name = "pydeck"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403 },
+]
+
+[[package]]
+name = "pydub"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/d4/70a265e4bcd43e97480ae62da69396ef4507c8f9cfd179005ee731c92a04/pymupdf-1.26.3.tar.gz", hash = "sha256:b7d2c3ffa9870e1e4416d18862f5ccd356af5fe337b4511093bbbce2ca73b7e5", size = 75990308 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/d3/c7af70545cd3097a869fd635bb6222108d3a0fb28c0b8254754a126c4cbb/pymupdf-1.26.3-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ded891963944e5f13b03b88f6d9e982e816a4ec8689fe360876eef000c161f2b", size = 23057205 },
+    { url = "https://files.pythonhosted.org/packages/04/3d/ec5b69bfeaa5deefa7141fc0b20d77bb20404507cf17196b4eb59f1f2977/pymupdf-1.26.3-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:436a33c738bb10eadf00395d18a6992b801ffb26521ee1f361ae786dd283327a", size = 22406630 },
+    { url = "https://files.pythonhosted.org/packages/fc/20/661d3894bb05ad75ed6ca103ee2c3fa44d88a458b5c8d4a946b9c0f2569b/pymupdf-1.26.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a2d7a3cd442f12f05103cb3bb1415111517f0a97162547a3720f3bbbc5e0b51c", size = 23450287 },
+    { url = "https://files.pythonhosted.org/packages/9c/7f/21828f018e65b16a033731d21f7b46d93fa81c6e8257f769ca4a1c2a1cb0/pymupdf-1.26.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:454f38c8cf07eb333eb4646dca10517b6e90f57ce2daa2265a78064109d85555", size = 24057319 },
+    { url = "https://files.pythonhosted.org/packages/71/5d/e8f88cd5a45b8f5fa6590ce8cef3ce0fad30eac6aac8aea12406f95bee7d/pymupdf-1.26.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:759b75d2f710ff4edf8d097d2e98f60e9ecef47632cead6f949b3412facdb9f0", size = 24261350 },
+    { url = "https://files.pythonhosted.org/packages/82/22/ecc560e4f281b5dffafbf3a81f023d268b1746d028044f495115b74a2e70/pymupdf-1.26.3-cp39-abi3-win32.whl", hash = "sha256:a839ed44742faa1cd4956bb18068fe5aae435d67ce915e901318646c4e7bbea6", size = 17116371 },
+    { url = "https://files.pythonhosted.org/packages/4a/26/8c72973b8833a72785cedc3981eb59b8ac7075942718bbb7b69b352cdde4/pymupdf-1.26.3-cp39-abi3-win_amd64.whl", hash = "sha256:b4cd5124d05737944636cf45fc37ce5824f10e707b0342efe109c7b6bd37a9cc", size = 18735124 },
 ]
 
 [[package]]
@@ -1528,12 +2444,76 @@ wheels = [
 ]
 
 [[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556 },
+]
+
+[[package]]
+name = "python-magic"
+version = "0.4.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840 },
+]
+
+[[package]]
+name = "python-magic-bin"
+version = "0.4.14"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/5d/10b9ac745d9fd2f7151a2ab901e6bb6983dbd70e87c71111f54859d1ca2e/python_magic_bin-0.4.14-py2.py3-none-win32.whl", hash = "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892", size = 397784 },
+    { url = "https://files.pythonhosted.org/packages/07/c2/094e3d62b906d952537196603a23aec4bcd7c6126bf80eb14e6f9f4be3a2/python_magic_bin-0.4.14-py2.py3-none-win_amd64.whl", hash = "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69", size = 409299 },
+]
+
+[[package]]
+name = "python-pptx"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "pillow" },
+    { name = "typing-extensions" },
+    { name = "xlsxwriter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788 },
+]
+
+[[package]]
+name = "pytubefix"
+version = "9.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/8a/2611bd7297e4b3ee1973c4d78e79f5a416cfebe89d4783f7da6f45c6b5d4/pytubefix-9.3.0.tar.gz", hash = "sha256:bcf7eeb4810f8710d31d6bce071475bd83fbd7ad6c978e32dda9a4802d0b0feb", size = 753289 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/9d/12e95c594beebe4fcbdddf97e5f571b2af7a2a0da34b6d5f560672d84f8c/pytubefix-9.3.0-py3-none-any.whl", hash = "sha256:97aeb82b4467e3bbf6703aafe618072559cc880dc66c94001b85e5718cf2cf17", size = 760193 },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225 },
 ]
 
 [[package]]
@@ -1660,6 +2640,35 @@ wheels = [
 ]
 
 [[package]]
+name = "readability-lxml"
+version = "0.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "cssselect" },
+    { name = "lxml", extra = ["html-clean"] },
+    { name = "lxml-html-clean", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/3e/dc87d97532ddad58af786ec89c7036182e352574c1cba37bf2bf783d2b15/readability_lxml-0.8.4.1.tar.gz", hash = "sha256:9d2924f5942dd7f37fb4da353263b22a3e877ccf922d0e45e348e4177b035a53", size = 22874 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/75/2cc58965097e351415af420be81c4665cf80da52a17ef43c01ffbe2caf91/readability_lxml-0.8.4.1-py3-none-any.whl", hash = "sha256:874c0cea22c3bf2b78c7f8df831bfaad3c0a89b7301d45a188db581652b4b465", size = 19912 },
+]
+
+[[package]]
+name = "referencing"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775 },
+]
+
+[[package]]
 name = "regex"
 version = "2024.11.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1756,6 +2765,132 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/aa/4456d84bbb54adc6a916fb10c9b374f78ac840337644e4a5eda229c81275/rpds_py-0.26.0.tar.gz", hash = "sha256:20dae58a859b0906f0685642e591056f1e787f3a8b39c8e8749a45dc7d26bdb0", size = 27385 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/31/1459645f036c3dfeacef89e8e5825e430c77dde8489f3b99eaafcd4a60f5/rpds_py-0.26.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:4c70c70f9169692b36307a95f3d8c0a9fcd79f7b4a383aad5eaa0e9718b79b37", size = 372466 },
+    { url = "https://files.pythonhosted.org/packages/dd/ff/3d0727f35836cc8773d3eeb9a46c40cc405854e36a8d2e951f3a8391c976/rpds_py-0.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:777c62479d12395bfb932944e61e915741e364c843afc3196b694db3d669fcd0", size = 357825 },
+    { url = "https://files.pythonhosted.org/packages/bf/ce/badc5e06120a54099ae287fa96d82cbb650a5f85cf247ffe19c7b157fd1f/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec671691e72dff75817386aa02d81e708b5a7ec0dec6669ec05213ff6b77e1bd", size = 381530 },
+    { url = "https://files.pythonhosted.org/packages/1e/a5/fa5d96a66c95d06c62d7a30707b6a4cfec696ab8ae280ee7be14e961e118/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6a1cb5d6ce81379401bbb7f6dbe3d56de537fb8235979843f0d53bc2e9815a79", size = 396933 },
+    { url = "https://files.pythonhosted.org/packages/00/a7/7049d66750f18605c591a9db47d4a059e112a0c9ff8de8daf8fa0f446bba/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4f789e32fa1fb6a7bf890e0124e7b42d1e60d28ebff57fe806719abb75f0e9a3", size = 513973 },
+    { url = "https://files.pythonhosted.org/packages/0e/f1/528d02c7d6b29d29fac8fd784b354d3571cc2153f33f842599ef0cf20dd2/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c55b0a669976cf258afd718de3d9ad1b7d1fe0a91cd1ab36f38b03d4d4aeaaf", size = 402293 },
+    { url = "https://files.pythonhosted.org/packages/15/93/fde36cd6e4685df2cd08508f6c45a841e82f5bb98c8d5ecf05649522acb5/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c70d9ec912802ecfd6cd390dadb34a9578b04f9bcb8e863d0a7598ba5e9e7ccc", size = 383787 },
+    { url = "https://files.pythonhosted.org/packages/69/f2/5007553aaba1dcae5d663143683c3dfd03d9395289f495f0aebc93e90f24/rpds_py-0.26.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3021933c2cb7def39d927b9862292e0f4c75a13d7de70eb0ab06efed4c508c19", size = 416312 },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/ce52c75c1e624a79e48a69e611f1c08844564e44c85db2b6f711d76d10ce/rpds_py-0.26.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8a7898b6ca3b7d6659e55cdac825a2e58c638cbf335cde41f4619e290dd0ad11", size = 558403 },
+    { url = "https://files.pythonhosted.org/packages/79/d5/e119db99341cc75b538bf4cb80504129fa22ce216672fb2c28e4a101f4d9/rpds_py-0.26.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:12bff2ad9447188377f1b2794772f91fe68bb4bbfa5a39d7941fbebdbf8c500f", size = 588323 },
+    { url = "https://files.pythonhosted.org/packages/93/94/d28272a0b02f5fe24c78c20e13bbcb95f03dc1451b68e7830ca040c60bd6/rpds_py-0.26.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:191aa858f7d4902e975d4cf2f2d9243816c91e9605070aeb09c0a800d187e323", size = 554541 },
+    { url = "https://files.pythonhosted.org/packages/93/e0/8c41166602f1b791da892d976057eba30685486d2e2c061ce234679c922b/rpds_py-0.26.0-cp310-cp310-win32.whl", hash = "sha256:b37a04d9f52cb76b6b78f35109b513f6519efb481d8ca4c321f6a3b9580b3f45", size = 220442 },
+    { url = "https://files.pythonhosted.org/packages/87/f0/509736bb752a7ab50fb0270c2a4134d671a7b3038030837e5536c3de0e0b/rpds_py-0.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:38721d4c9edd3eb6670437d8d5e2070063f305bfa2d5aa4278c51cedcd508a84", size = 231314 },
+    { url = "https://files.pythonhosted.org/packages/09/4c/4ee8f7e512030ff79fda1df3243c88d70fc874634e2dbe5df13ba4210078/rpds_py-0.26.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:9e8cb77286025bdb21be2941d64ac6ca016130bfdcd228739e8ab137eb4406ed", size = 372610 },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3dc16be00f14fc1f03c71b1d67c8df98263ab2710a2fbd65a6193214a527/rpds_py-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5e09330b21d98adc8ccb2dbb9fc6cb434e8908d4c119aeaa772cb1caab5440a0", size = 358032 },
+    { url = "https://files.pythonhosted.org/packages/e7/5a/7f1bf8f045da2866324a08ae80af63e64e7bfaf83bd31f865a7b91a58601/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c9c1b92b774b2e68d11193dc39620d62fd8ab33f0a3c77ecdabe19c179cdbc1", size = 381525 },
+    { url = "https://files.pythonhosted.org/packages/45/8a/04479398c755a066ace10e3d158866beb600867cacae194c50ffa783abd0/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:824e6d3503ab990d7090768e4dfd9e840837bae057f212ff9f4f05ec6d1975e7", size = 397089 },
+    { url = "https://files.pythonhosted.org/packages/72/88/9203f47268db488a1b6d469d69c12201ede776bb728b9d9f29dbfd7df406/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ad7fd2258228bf288f2331f0a6148ad0186b2e3643055ed0db30990e59817a6", size = 514255 },
+    { url = "https://files.pythonhosted.org/packages/f5/b4/01ce5d1e853ddf81fbbd4311ab1eff0b3cf162d559288d10fd127e2588b5/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0dc23bbb3e06ec1ea72d515fb572c1fea59695aefbffb106501138762e1e915e", size = 402283 },
+    { url = "https://files.pythonhosted.org/packages/34/a2/004c99936997bfc644d590a9defd9e9c93f8286568f9c16cdaf3e14429a7/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d80bf832ac7b1920ee29a426cdca335f96a2b5caa839811803e999b41ba9030d", size = 383881 },
+    { url = "https://files.pythonhosted.org/packages/05/1b/ef5fba4a8f81ce04c427bfd96223f92f05e6cd72291ce9d7523db3b03a6c/rpds_py-0.26.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0919f38f5542c0a87e7b4afcafab6fd2c15386632d249e9a087498571250abe3", size = 415822 },
+    { url = "https://files.pythonhosted.org/packages/16/80/5c54195aec456b292f7bd8aa61741c8232964063fd8a75fdde9c1e982328/rpds_py-0.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d422b945683e409000c888e384546dbab9009bb92f7c0b456e217988cf316107", size = 558347 },
+    { url = "https://files.pythonhosted.org/packages/f2/1c/1845c1b1fd6d827187c43afe1841d91678d7241cbdb5420a4c6de180a538/rpds_py-0.26.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:77a7711fa562ba2da1aa757e11024ad6d93bad6ad7ede5afb9af144623e5f76a", size = 587956 },
+    { url = "https://files.pythonhosted.org/packages/2e/ff/9e979329dd131aa73a438c077252ddabd7df6d1a7ad7b9aacf6261f10faa/rpds_py-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:238e8c8610cb7c29460e37184f6799547f7e09e6a9bdbdab4e8edb90986a2318", size = 554363 },
+    { url = "https://files.pythonhosted.org/packages/00/8b/d78cfe034b71ffbe72873a136e71acc7a831a03e37771cfe59f33f6de8a2/rpds_py-0.26.0-cp311-cp311-win32.whl", hash = "sha256:893b022bfbdf26d7bedb083efeea624e8550ca6eb98bf7fea30211ce95b9201a", size = 220123 },
+    { url = "https://files.pythonhosted.org/packages/94/c1/3c8c94c7dd3905dbfde768381ce98778500a80db9924731d87ddcdb117e9/rpds_py-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:87a5531de9f71aceb8af041d72fc4cab4943648d91875ed56d2e629bef6d4c03", size = 231732 },
+    { url = "https://files.pythonhosted.org/packages/67/93/e936fbed1b734eabf36ccb5d93c6a2e9246fbb13c1da011624b7286fae3e/rpds_py-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:de2713f48c1ad57f89ac25b3cb7daed2156d8e822cf0eca9b96a6f990718cc41", size = 221917 },
+    { url = "https://files.pythonhosted.org/packages/ea/86/90eb87c6f87085868bd077c7a9938006eb1ce19ed4d06944a90d3560fce2/rpds_py-0.26.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:894514d47e012e794f1350f076c427d2347ebf82f9b958d554d12819849a369d", size = 363933 },
+    { url = "https://files.pythonhosted.org/packages/63/78/4469f24d34636242c924626082b9586f064ada0b5dbb1e9d096ee7a8e0c6/rpds_py-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc921b96fa95a097add244da36a1d9e4f3039160d1d30f1b35837bf108c21136", size = 350447 },
+    { url = "https://files.pythonhosted.org/packages/ad/91/c448ed45efdfdade82348d5e7995e15612754826ea640afc20915119734f/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e1157659470aa42a75448b6e943c895be8c70531c43cb78b9ba990778955582", size = 384711 },
+    { url = "https://files.pythonhosted.org/packages/ec/43/e5c86fef4be7f49828bdd4ecc8931f0287b1152c0bb0163049b3218740e7/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:521ccf56f45bb3a791182dc6b88ae5f8fa079dd705ee42138c76deb1238e554e", size = 400865 },
+    { url = "https://files.pythonhosted.org/packages/55/34/e00f726a4d44f22d5c5fe2e5ddd3ac3d7fd3f74a175607781fbdd06fe375/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9def736773fd56b305c0eef698be5192c77bfa30d55a0e5885f80126c4831a15", size = 517763 },
+    { url = "https://files.pythonhosted.org/packages/52/1c/52dc20c31b147af724b16104500fba13e60123ea0334beba7b40e33354b4/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdad4ea3b4513b475e027be79e5a0ceac8ee1c113a1a11e5edc3c30c29f964d8", size = 406651 },
+    { url = "https://files.pythonhosted.org/packages/2e/77/87d7bfabfc4e821caa35481a2ff6ae0b73e6a391bb6b343db2c91c2b9844/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82b165b07f416bdccf5c84546a484cc8f15137ca38325403864bfdf2b5b72f6a", size = 386079 },
+    { url = "https://files.pythonhosted.org/packages/e3/d4/7f2200c2d3ee145b65b3cddc4310d51f7da6a26634f3ac87125fd789152a/rpds_py-0.26.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d04cab0a54b9dba4d278fe955a1390da3cf71f57feb78ddc7cb67cbe0bd30323", size = 421379 },
+    { url = "https://files.pythonhosted.org/packages/ae/13/9fdd428b9c820869924ab62236b8688b122baa22d23efdd1c566938a39ba/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:79061ba1a11b6a12743a2b0f72a46aa2758613d454aa6ba4f5a265cc48850158", size = 562033 },
+    { url = "https://files.pythonhosted.org/packages/f3/e1/b69686c3bcbe775abac3a4c1c30a164a2076d28df7926041f6c0eb5e8d28/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f405c93675d8d4c5ac87364bb38d06c988e11028a64b52a47158a355079661f3", size = 591639 },
+    { url = "https://files.pythonhosted.org/packages/5c/c9/1e3d8c8863c84a90197ac577bbc3d796a92502124c27092413426f670990/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dafd4c44b74aa4bed4b250f1aed165b8ef5de743bcca3b88fc9619b6087093d2", size = 557105 },
+    { url = "https://files.pythonhosted.org/packages/9f/c5/90c569649057622959f6dcc40f7b516539608a414dfd54b8d77e3b201ac0/rpds_py-0.26.0-cp312-cp312-win32.whl", hash = "sha256:3da5852aad63fa0c6f836f3359647870e21ea96cf433eb393ffa45263a170d44", size = 223272 },
+    { url = "https://files.pythonhosted.org/packages/7d/16/19f5d9f2a556cfed454eebe4d354c38d51c20f3db69e7b4ce6cff904905d/rpds_py-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf47cfdabc2194a669dcf7a8dbba62e37a04c5041d2125fae0233b720da6f05c", size = 234995 },
+    { url = "https://files.pythonhosted.org/packages/83/f0/7935e40b529c0e752dfaa7880224771b51175fce08b41ab4a92eb2fbdc7f/rpds_py-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:20ab1ae4fa534f73647aad289003f1104092890849e0266271351922ed5574f8", size = 223198 },
+    { url = "https://files.pythonhosted.org/packages/6a/67/bb62d0109493b12b1c6ab00de7a5566aa84c0e44217c2d94bee1bd370da9/rpds_py-0.26.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:696764a5be111b036256c0b18cd29783fab22154690fc698062fc1b0084b511d", size = 363917 },
+    { url = "https://files.pythonhosted.org/packages/4b/f3/34e6ae1925a5706c0f002a8d2d7f172373b855768149796af87bd65dcdb9/rpds_py-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6c15d2080a63aaed876e228efe4f814bc7889c63b1e112ad46fdc8b368b9e1", size = 350073 },
+    { url = "https://files.pythonhosted.org/packages/75/83/1953a9d4f4e4de7fd0533733e041c28135f3c21485faaef56a8aadbd96b5/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:390e3170babf42462739a93321e657444f0862c6d722a291accc46f9d21ed04e", size = 384214 },
+    { url = "https://files.pythonhosted.org/packages/48/0e/983ed1b792b3322ea1d065e67f4b230f3b96025f5ce3878cc40af09b7533/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7da84c2c74c0f5bc97d853d9e17bb83e2dcafcff0dc48286916001cc114379a1", size = 400113 },
+    { url = "https://files.pythonhosted.org/packages/69/7f/36c0925fff6f660a80be259c5b4f5e53a16851f946eb080351d057698528/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c5fe114a6dd480a510b6d3661d09d67d1622c4bf20660a474507aaee7eeeee9", size = 515189 },
+    { url = "https://files.pythonhosted.org/packages/13/45/cbf07fc03ba7a9b54662c9badb58294ecfb24f828b9732970bd1a431ed5c/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3100b3090269f3a7ea727b06a6080d4eb7439dca4c0e91a07c5d133bb1727ea7", size = 406998 },
+    { url = "https://files.pythonhosted.org/packages/6c/b0/8fa5e36e58657997873fd6a1cf621285ca822ca75b4b3434ead047daa307/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c03c9b0c64afd0320ae57de4c982801271c0c211aa2d37f3003ff5feb75bb04", size = 385903 },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/b25437772f9f57d7a9fbd73ed86d0dcd76b4c7c6998348c070d90f23e315/rpds_py-0.26.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5963b72ccd199ade6ee493723d18a3f21ba7d5b957017607f815788cef50eaf1", size = 419785 },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/63ffa55743dfcb4baf2e9e77a0b11f7f97ed96a54558fcb5717a4b2cd732/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9da4e873860ad5bab3291438525cae80169daecbfafe5657f7f5fb4d6b3f96b9", size = 561329 },
+    { url = "https://files.pythonhosted.org/packages/2f/07/1f4f5e2886c480a2346b1e6759c00278b8a69e697ae952d82ae2e6ee5db0/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5afaddaa8e8c7f1f7b4c5c725c0070b6eed0228f705b90a1732a48e84350f4e9", size = 590875 },
+    { url = "https://files.pythonhosted.org/packages/cc/bc/e6639f1b91c3a55f8c41b47d73e6307051b6e246254a827ede730624c0f8/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4916dc96489616a6f9667e7526af8fa693c0fdb4f3acb0e5d9f4400eb06a47ba", size = 556636 },
+    { url = "https://files.pythonhosted.org/packages/05/4c/b3917c45566f9f9a209d38d9b54a1833f2bb1032a3e04c66f75726f28876/rpds_py-0.26.0-cp313-cp313-win32.whl", hash = "sha256:2a343f91b17097c546b93f7999976fd6c9d5900617aa848c81d794e062ab302b", size = 222663 },
+    { url = "https://files.pythonhosted.org/packages/e0/0b/0851bdd6025775aaa2365bb8de0697ee2558184c800bfef8d7aef5ccde58/rpds_py-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:0a0b60701f2300c81b2ac88a5fb893ccfa408e1c4a555a77f908a2596eb875a5", size = 234428 },
+    { url = "https://files.pythonhosted.org/packages/ed/e8/a47c64ed53149c75fb581e14a237b7b7cd18217e969c30d474d335105622/rpds_py-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:257d011919f133a4746958257f2c75238e3ff54255acd5e3e11f3ff41fd14256", size = 222571 },
+    { url = "https://files.pythonhosted.org/packages/89/bf/3d970ba2e2bcd17d2912cb42874107390f72873e38e79267224110de5e61/rpds_py-0.26.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:529c8156d7506fba5740e05da8795688f87119cce330c244519cf706a4a3d618", size = 360475 },
+    { url = "https://files.pythonhosted.org/packages/82/9f/283e7e2979fc4ec2d8ecee506d5a3675fce5ed9b4b7cb387ea5d37c2f18d/rpds_py-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f53ec51f9d24e9638a40cabb95078ade8c99251945dad8d57bf4aabe86ecee35", size = 346692 },
+    { url = "https://files.pythonhosted.org/packages/e3/03/7e50423c04d78daf391da3cc4330bdb97042fc192a58b186f2d5deb7befd/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab504c4d654e4a29558eaa5bb8cea5fdc1703ea60a8099ffd9c758472cf913f", size = 379415 },
+    { url = "https://files.pythonhosted.org/packages/57/00/d11ee60d4d3b16808432417951c63df803afb0e0fc672b5e8d07e9edaaae/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd0641abca296bc1a00183fe44f7fced8807ed49d501f188faa642d0e4975b83", size = 391783 },
+    { url = "https://files.pythonhosted.org/packages/08/b3/1069c394d9c0d6d23c5b522e1f6546b65793a22950f6e0210adcc6f97c3e/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69b312fecc1d017b5327afa81d4da1480f51c68810963a7336d92203dbb3d4f1", size = 512844 },
+    { url = "https://files.pythonhosted.org/packages/08/3b/c4fbf0926800ed70b2c245ceca99c49f066456755f5d6eb8863c2c51e6d0/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c741107203954f6fc34d3066d213d0a0c40f7bb5aafd698fb39888af277c70d8", size = 402105 },
+    { url = "https://files.pythonhosted.org/packages/1c/b0/db69b52ca07413e568dae9dc674627a22297abb144c4d6022c6d78f1e5cc/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc3e55a7db08dc9a6ed5fb7103019d2c1a38a349ac41901f9f66d7f95750942f", size = 383440 },
+    { url = "https://files.pythonhosted.org/packages/4c/e1/c65255ad5b63903e56b3bb3ff9dcc3f4f5c3badde5d08c741ee03903e951/rpds_py-0.26.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9e851920caab2dbcae311fd28f4313c6953993893eb5c1bb367ec69d9a39e7ed", size = 412759 },
+    { url = "https://files.pythonhosted.org/packages/e4/22/bb731077872377a93c6e93b8a9487d0406c70208985831034ccdeed39c8e/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dfbf280da5f876d0b00c81f26bedce274e72a678c28845453885a9b3c22ae632", size = 556032 },
+    { url = "https://files.pythonhosted.org/packages/e0/8b/393322ce7bac5c4530fb96fc79cc9ea2f83e968ff5f6e873f905c493e1c4/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1cc81d14ddfa53d7f3906694d35d54d9d3f850ef8e4e99ee68bc0d1e5fed9a9c", size = 585416 },
+    { url = "https://files.pythonhosted.org/packages/49/ae/769dc372211835bf759319a7aae70525c6eb523e3371842c65b7ef41c9c6/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dca83c498b4650a91efcf7b88d669b170256bf8017a5db6f3e06c2bf031f57e0", size = 554049 },
+    { url = "https://files.pythonhosted.org/packages/6b/f9/4c43f9cc203d6ba44ce3146246cdc38619d92c7bd7bad4946a3491bd5b70/rpds_py-0.26.0-cp313-cp313t-win32.whl", hash = "sha256:4d11382bcaf12f80b51d790dee295c56a159633a8e81e6323b16e55d81ae37e9", size = 218428 },
+    { url = "https://files.pythonhosted.org/packages/7e/8b/9286b7e822036a4a977f2f1e851c7345c20528dbd56b687bb67ed68a8ede/rpds_py-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff110acded3c22c033e637dd8896e411c7d3a11289b2edf041f86663dbc791e9", size = 231524 },
+    { url = "https://files.pythonhosted.org/packages/55/07/029b7c45db910c74e182de626dfdae0ad489a949d84a468465cd0ca36355/rpds_py-0.26.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:da619979df60a940cd434084355c514c25cf8eb4cf9a508510682f6c851a4f7a", size = 364292 },
+    { url = "https://files.pythonhosted.org/packages/13/d1/9b3d3f986216b4d1f584878dca15ce4797aaf5d372d738974ba737bf68d6/rpds_py-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea89a2458a1a75f87caabefe789c87539ea4e43b40f18cff526052e35bbb4fdf", size = 350334 },
+    { url = "https://files.pythonhosted.org/packages/18/98/16d5e7bc9ec715fa9668731d0cf97f6b032724e61696e2db3d47aeb89214/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feac1045b3327a45944e7dcbeb57530339f6b17baff154df51ef8b0da34c8c12", size = 384875 },
+    { url = "https://files.pythonhosted.org/packages/f9/13/aa5e2b1ec5ab0e86a5c464d53514c0467bec6ba2507027d35fc81818358e/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b818a592bd69bfe437ee8368603d4a2d928c34cffcdf77c2e761a759ffd17d20", size = 399993 },
+    { url = "https://files.pythonhosted.org/packages/17/03/8021810b0e97923abdbab6474c8b77c69bcb4b2c58330777df9ff69dc559/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a8b0dd8648709b62d9372fc00a57466f5fdeefed666afe3fea5a6c9539a0331", size = 516683 },
+    { url = "https://files.pythonhosted.org/packages/dc/b1/da8e61c87c2f3d836954239fdbbfb477bb7b54d74974d8f6fcb34342d166/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d3498ad0df07d81112aa6ec6c95a7e7b1ae00929fb73e7ebee0f3faaeabad2f", size = 408825 },
+    { url = "https://files.pythonhosted.org/packages/38/bc/1fc173edaaa0e52c94b02a655db20697cb5fa954ad5a8e15a2c784c5cbdd/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24a4146ccb15be237fdef10f331c568e1b0e505f8c8c9ed5d67759dac58ac246", size = 387292 },
+    { url = "https://files.pythonhosted.org/packages/7c/eb/3a9bb4bd90867d21916f253caf4f0d0be7098671b6715ad1cead9fe7bab9/rpds_py-0.26.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a9a63785467b2d73635957d32a4f6e73d5e4df497a16a6392fa066b753e87387", size = 420435 },
+    { url = "https://files.pythonhosted.org/packages/cd/16/e066dcdb56f5632713445271a3f8d3d0b426d51ae9c0cca387799df58b02/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:de4ed93a8c91debfd5a047be327b7cc8b0cc6afe32a716bbbc4aedca9e2a83af", size = 562410 },
+    { url = "https://files.pythonhosted.org/packages/60/22/ddbdec7eb82a0dc2e455be44c97c71c232983e21349836ce9f272e8a3c29/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:caf51943715b12af827696ec395bfa68f090a4c1a1d2509eb4e2cb69abbbdb33", size = 590724 },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/95744085e65b7187d83f2fcb0bef70716a1ea0a9e5d8f7f39a86e5d83424/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4a59e5bc386de021f56337f757301b337d7ab58baa40174fb150accd480bc953", size = 558285 },
+    { url = "https://files.pythonhosted.org/packages/37/37/6309a75e464d1da2559446f9c811aa4d16343cebe3dbb73701e63f760caa/rpds_py-0.26.0-cp314-cp314-win32.whl", hash = "sha256:92c8db839367ef16a662478f0a2fe13e15f2227da3c1430a782ad0f6ee009ec9", size = 223459 },
+    { url = "https://files.pythonhosted.org/packages/d9/6f/8e9c11214c46098b1d1391b7e02b70bb689ab963db3b19540cba17315291/rpds_py-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:b0afb8cdd034150d4d9f53926226ed27ad15b7f465e93d7468caaf5eafae0d37", size = 236083 },
+    { url = "https://files.pythonhosted.org/packages/47/af/9c4638994dd623d51c39892edd9d08e8be8220a4b7e874fa02c2d6e91955/rpds_py-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:ca3f059f4ba485d90c8dc75cb5ca897e15325e4e609812ce57f896607c1c0867", size = 223291 },
+    { url = "https://files.pythonhosted.org/packages/4d/db/669a241144460474aab03e254326b32c42def83eb23458a10d163cb9b5ce/rpds_py-0.26.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5afea17ab3a126006dc2f293b14ffc7ef3c85336cf451564a0515ed7648033da", size = 361445 },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/133f61cc5807c6c2fd086a46df0eb8f63a23f5df8306ff9f6d0fd168fecc/rpds_py-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:69f0c0a3df7fd3a7eec50a00396104bb9a843ea6d45fcc31c2d5243446ffd7a7", size = 347206 },
+    { url = "https://files.pythonhosted.org/packages/05/bf/0e8fb4c05f70273469eecf82f6ccf37248558526a45321644826555db31b/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:801a71f70f9813e82d2513c9a96532551fce1e278ec0c64610992c49c04c2dad", size = 380330 },
+    { url = "https://files.pythonhosted.org/packages/d4/a8/060d24185d8b24d3923322f8d0ede16df4ade226a74e747b8c7c978e3dd3/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df52098cde6d5e02fa75c1f6244f07971773adb4a26625edd5c18fee906fa84d", size = 392254 },
+    { url = "https://files.pythonhosted.org/packages/b9/7b/7c2e8a9ee3e6bc0bae26bf29f5219955ca2fbb761dca996a83f5d2f773fe/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9bc596b30f86dc6f0929499c9e574601679d0341a0108c25b9b358a042f51bca", size = 516094 },
+    { url = "https://files.pythonhosted.org/packages/75/d6/f61cafbed8ba1499b9af9f1777a2a199cd888f74a96133d8833ce5eaa9c5/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9dfbe56b299cf5875b68eb6f0ebaadc9cac520a1989cac0db0765abfb3709c19", size = 402889 },
+    { url = "https://files.pythonhosted.org/packages/92/19/c8ac0a8a8df2dd30cdec27f69298a5c13e9029500d6d76718130f5e5be10/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac64f4b2bdb4ea622175c9ab7cf09444e412e22c0e02e906978b3b488af5fde8", size = 384301 },
+    { url = "https://files.pythonhosted.org/packages/41/e1/6b1859898bc292a9ce5776016c7312b672da00e25cec74d7beced1027286/rpds_py-0.26.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:181ef9b6bbf9845a264f9aa45c31836e9f3c1f13be565d0d010e964c661d1e2b", size = 412891 },
+    { url = "https://files.pythonhosted.org/packages/ef/b9/ceb39af29913c07966a61367b3c08b4f71fad841e32c6b59a129d5974698/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:49028aa684c144ea502a8e847d23aed5e4c2ef7cadfa7d5eaafcb40864844b7a", size = 557044 },
+    { url = "https://files.pythonhosted.org/packages/2f/27/35637b98380731a521f8ec4f3fd94e477964f04f6b2f8f7af8a2d889a4af/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e5d524d68a474a9688336045bbf76cb0def88549c1b2ad9dbfec1fb7cfbe9170", size = 585774 },
+    { url = "https://files.pythonhosted.org/packages/52/d9/3f0f105420fecd18551b678c9a6ce60bd23986098b252a56d35781b3e7e9/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1851f429b822831bd2edcbe0cfd12ee9ea77868f8d3daf267b189371671c80e", size = 554886 },
+    { url = "https://files.pythonhosted.org/packages/6b/c5/347c056a90dc8dd9bc240a08c527315008e1b5042e7a4cf4ac027be9d38a/rpds_py-0.26.0-cp314-cp314t-win32.whl", hash = "sha256:7bdb17009696214c3b66bb3590c6d62e14ac5935e53e929bcdbc5a495987a84f", size = 219027 },
+    { url = "https://files.pythonhosted.org/packages/75/04/5302cea1aa26d886d34cadbf2dc77d90d7737e576c0065f357b96dc7a1a6/rpds_py-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f14440b9573a6f76b4ee4770c13f0b5921f71dde3b6fcb8dabbefd13b7fe05d7", size = 232821 },
+    { url = "https://files.pythonhosted.org/packages/ef/9a/1f033b0b31253d03d785b0cd905bc127e555ab496ea6b4c7c2e1f951f2fd/rpds_py-0.26.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3c0909c5234543ada2515c05dc08595b08d621ba919629e94427e8e03539c958", size = 373226 },
+    { url = "https://files.pythonhosted.org/packages/58/29/5f88023fd6aaaa8ca3c4a6357ebb23f6f07da6079093ccf27c99efce87db/rpds_py-0.26.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:c1fb0cda2abcc0ac62f64e2ea4b4e64c57dfd6b885e693095460c61bde7bb18e", size = 359230 },
+    { url = "https://files.pythonhosted.org/packages/6c/6c/13eaebd28b439da6964dde22712b52e53fe2824af0223b8e403249d10405/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84d142d2d6cf9b31c12aa4878d82ed3b2324226270b89b676ac62ccd7df52d08", size = 382363 },
+    { url = "https://files.pythonhosted.org/packages/55/fc/3bb9c486b06da19448646f96147796de23c5811ef77cbfc26f17307b6a9d/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a547e21c5610b7e9093d870be50682a6a6cf180d6da0f42c47c306073bfdbbf6", size = 397146 },
+    { url = "https://files.pythonhosted.org/packages/15/18/9d1b79eb4d18e64ba8bba9e7dec6f9d6920b639f22f07ee9368ca35d4673/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:35e9a70a0f335371275cdcd08bc5b8051ac494dd58bff3bbfb421038220dc871", size = 514804 },
+    { url = "https://files.pythonhosted.org/packages/4f/5a/175ad7191bdbcd28785204621b225ad70e85cdfd1e09cc414cb554633b21/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0dfa6115c6def37905344d56fb54c03afc49104e2ca473d5dedec0f6606913b4", size = 402820 },
+    { url = "https://files.pythonhosted.org/packages/11/45/6a67ecf6d61c4d4aff4bc056e864eec4b2447787e11d1c2c9a0242c6e92a/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:313cfcd6af1a55a286a3c9a25f64af6d0e46cf60bc5798f1db152d97a216ff6f", size = 384567 },
+    { url = "https://files.pythonhosted.org/packages/a1/ba/16589da828732b46454c61858950a78fe4c931ea4bf95f17432ffe64b241/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f7bf2496fa563c046d05e4d232d7b7fd61346e2402052064b773e5c378bf6f73", size = 416520 },
+    { url = "https://files.pythonhosted.org/packages/81/4b/00092999fc7c0c266045e984d56b7314734cc400a6c6dc4d61a35f135a9d/rpds_py-0.26.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:aa81873e2c8c5aa616ab8e017a481a96742fdf9313c40f14338ca7dbf50cb55f", size = 559362 },
+    { url = "https://files.pythonhosted.org/packages/96/0c/43737053cde1f93ac4945157f7be1428724ab943e2132a0d235a7e161d4e/rpds_py-0.26.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:68ffcf982715f5b5b7686bdd349ff75d422e8f22551000c24b30eaa1b7f7ae84", size = 588113 },
+    { url = "https://files.pythonhosted.org/packages/46/46/8e38f6161466e60a997ed7e9951ae5de131dedc3cf778ad35994b4af823d/rpds_py-0.26.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6188de70e190847bb6db3dc3981cbadff87d27d6fe9b4f0e18726d55795cee9b", size = 555429 },
+    { url = "https://files.pythonhosted.org/packages/2c/ac/65da605e9f1dd643ebe615d5bbd11b6efa1d69644fc4bf623ea5ae385a82/rpds_py-0.26.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:1c962145c7473723df9722ba4c058de12eb5ebedcb4e27e7d902920aa3831ee8", size = 231950 },
+    { url = "https://files.pythonhosted.org/packages/51/f2/b5c85b758a00c513bb0389f8fc8e61eb5423050c91c958cdd21843faa3e6/rpds_py-0.26.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f61a9326f80ca59214d1cceb0a09bb2ece5b2563d4e0cd37bfd5515c28510674", size = 373505 },
+    { url = "https://files.pythonhosted.org/packages/23/e0/25db45e391251118e915e541995bb5f5ac5691a3b98fb233020ba53afc9b/rpds_py-0.26.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:183f857a53bcf4b1b42ef0f57ca553ab56bdd170e49d8091e96c51c3d69ca696", size = 359468 },
+    { url = "https://files.pythonhosted.org/packages/0b/73/dd5ee6075bb6491be3a646b301dfd814f9486d924137a5098e61f0487e16/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:941c1cfdf4799d623cf3aa1d326a6b4fdb7a5799ee2687f3516738216d2262fb", size = 382680 },
+    { url = "https://files.pythonhosted.org/packages/2f/10/84b522ff58763a5c443f5bcedc1820240e454ce4e620e88520f04589e2ea/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72a8d9564a717ee291f554eeb4bfeafe2309d5ec0aa6c475170bdab0f9ee8e88", size = 397035 },
+    { url = "https://files.pythonhosted.org/packages/06/ea/8667604229a10a520fcbf78b30ccc278977dcc0627beb7ea2c96b3becef0/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:511d15193cbe013619dd05414c35a7dedf2088fcee93c6bbb7c77859765bd4e8", size = 514922 },
+    { url = "https://files.pythonhosted.org/packages/24/e6/9ed5b625c0661c4882fc8cdf302bf8e96c73c40de99c31e0b95ed37d508c/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aea1f9741b603a8d8fedb0ed5502c2bc0accbc51f43e2ad1337fe7259c2b77a5", size = 402822 },
+    { url = "https://files.pythonhosted.org/packages/8a/58/212c7b6fd51946047fb45d3733da27e2fa8f7384a13457c874186af691b1/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4019a9d473c708cf2f16415688ef0b4639e07abaa569d72f74745bbeffafa2c7", size = 384336 },
+    { url = "https://files.pythonhosted.org/packages/aa/f5/a40ba78748ae8ebf4934d4b88e77b98497378bc2c24ba55ebe87a4e87057/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:093d63b4b0f52d98ebae33b8c50900d3d67e0666094b1be7a12fffd7f65de74b", size = 416871 },
+    { url = "https://files.pythonhosted.org/packages/d5/a6/33b1fc0c9f7dcfcfc4a4353daa6308b3ece22496ceece348b3e7a7559a09/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2abe21d8ba64cded53a2a677e149ceb76dcf44284202d737178afe7ba540c1eb", size = 559439 },
+    { url = "https://files.pythonhosted.org/packages/71/2d/ceb3f9c12f8cfa56d34995097f6cd99da1325642c60d1b6680dd9df03ed8/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:4feb7511c29f8442cbbc28149a92093d32e815a28aa2c50d333826ad2a20fdf0", size = 588380 },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/9de62c2150ca8e2e5858acf3f4f4d0d180a38feef9fdab4078bea63d8dba/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e99685fc95d386da368013e7fb4269dd39c30d99f812a8372d62f244f662709c", size = 555334 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1765,12 +2900,30 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677 },
 ]
 
 [[package]]
@@ -1785,6 +2938,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
+]
+
+[[package]]
+name = "streamlit"
+version = "1.46.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altair" },
+    { name = "blinker" },
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "pyarrow" },
+    { name = "pydeck" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "toml" },
+    { name = "tornado" },
+    { name = "typing-extensions" },
+    { name = "watchdog", marker = "platform_system != 'Darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/7e/c7499c447b7021657fa5c851091072c1c7a26f1dda0369c21c0243fc35e7/streamlit-1.46.1.tar.gz", hash = "sha256:2cc4ad01cfeded9ad953a21829eb879b90aa77af4068c68397411c2d5c8862cf", size = 9651018 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/3b/35400175788cdd6a43c90dce1e7f567eb6843a3ba0612508c0f19ee31f5f/streamlit-1.46.1-py3-none-any.whl", hash = "sha256:dffa373230965f87ccc156abaff848d7d731920cf14106f3b99b1ea18076f728", size = 10051346 },
 ]
 
 [[package]]
@@ -1830,6 +3012,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/bb/4513da71cac187383541facd0291c4572b03ec23c561de5811781bbd988f/tiktoken-0.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc156cb314119a8bb9748257a2eaebd5cc0753b6cb491d26694ed42fc7cb3139", size = 1195649 },
     { url = "https://files.pythonhosted.org/packages/fa/5c/74e4c137530dd8504e97e3a41729b1103a4ac29036cbfd3250b11fd29451/tiktoken-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cd69372e8c9dd761f0ab873112aba55a0e3e506332dd9f7522ca466e817b1b7a", size = 1258465 },
     { url = "https://files.pythonhosted.org/packages/de/a8/8f499c179ec900783ffe133e9aab10044481679bb9aad78436d239eee716/tiktoken-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5ea0edb6f83dc56d794723286215918c1cde03712cbbafa0348b33448faf5b95", size = 894669 },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588 },
 ]
 
 [[package]]
@@ -1933,6 +3124,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1942,12 +3142,98 @@ wheels = [
 ]
 
 [[package]]
+name = "validators"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712 },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423 },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080 },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329 },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312 },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319 },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631 },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016 },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426 },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360 },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388 },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830 },
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423 },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082 },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330 },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878 },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883 },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252 },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521 },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958 },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918 },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388 },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828 },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437 },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096 },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332 },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152 },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096 },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523 },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790 },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165 },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160 },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395 },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841 },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440 },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098 },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329 },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111 },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054 },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496 },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829 },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217 },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195 },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109 },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343 },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599 },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207 },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155 },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884 },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
 ]
 
 [[package]]
@@ -1966,6 +3252,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083 },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/47/7704bac42ac6fe1710ae099b70e6a1e68ed173ef14792b647808c357da43/xlsxwriter-3.2.5.tar.gz", hash = "sha256:7e88469d607cdc920151c0ab3ce9cf1a83992d4b7bc730c5ffdd1a12115a7dbe", size = 213306 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/34/a22e6664211f0c8879521328000bdcae9bf6dbafa94a923e531f6d5b3f73/xlsxwriter-3.2.5-py3-none-any.whl", hash = "sha256:4f4824234e1eaf9d95df9a8fe974585ff91d0f5e3d3f12ace5b71e443c1c6abd", size = 172347 },
 ]
 
 [[package]]
@@ -2039,6 +3334,118 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/f8/f6c61fd794229cc3848d144f73754a0c107854372d7261419dcbbd286299/xxhash-3.5.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e2febf914ace002132aa09169cc572e0d8959d0f305f93d5828c4836f9bc5a6", size = 32020 },
     { url = "https://files.pythonhosted.org/packages/79/d3/c029c99801526f859e6b38d34ab87c08993bf3dcea34b11275775001638a/xxhash-3.5.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5d3a10609c51da2a1c0ea0293fc3968ca0a18bd73838455b5bca3069d7f8e32b", size = 40515 },
     { url = "https://files.pythonhosted.org/packages/62/e3/bef7b82c1997579c94de9ac5ea7626d01ae5858aa22bf4fcb38bf220cb3e/xxhash-3.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:5a74f23335b9689b66eb6dbe2a931a88fcd7a4c2cc4b1cb0edba8ce381c7a1da", size = 30064 },
+]
+
+[[package]]
+name = "yarl"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/fb/efaa23fa4e45537b827620f04cf8f3cd658b76642205162e072703a5b963/yarl-1.20.1.tar.gz", hash = "sha256:d017a4997ee50c91fd5466cef416231bb82177b93b029906cefc542ce14c35ac", size = 186428 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/65/7fed0d774abf47487c64be14e9223749468922817b5e8792b8a64792a1bb/yarl-1.20.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6032e6da6abd41e4acda34d75a816012717000fa6839f37124a47fcefc49bec4", size = 132910 },
+    { url = "https://files.pythonhosted.org/packages/8a/7b/988f55a52da99df9e56dc733b8e4e5a6ae2090081dc2754fc8fd34e60aa0/yarl-1.20.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2c7b34d804b8cf9b214f05015c4fee2ebe7ed05cf581e7192c06555c71f4446a", size = 90644 },
+    { url = "https://files.pythonhosted.org/packages/f7/de/30d98f03e95d30c7e3cc093759982d038c8833ec2451001d45ef4854edc1/yarl-1.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0c869f2651cc77465f6cd01d938d91a11d9ea5d798738c1dc077f3de0b5e5fed", size = 89322 },
+    { url = "https://files.pythonhosted.org/packages/e0/7a/f2f314f5ebfe9200724b0b748de2186b927acb334cf964fd312eb86fc286/yarl-1.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62915e6688eb4d180d93840cda4110995ad50c459bf931b8b3775b37c264af1e", size = 323786 },
+    { url = "https://files.pythonhosted.org/packages/15/3f/718d26f189db96d993d14b984ce91de52e76309d0fd1d4296f34039856aa/yarl-1.20.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:41ebd28167bc6af8abb97fec1a399f412eec5fd61a3ccbe2305a18b84fb4ca73", size = 319627 },
+    { url = "https://files.pythonhosted.org/packages/a5/76/8fcfbf5fa2369157b9898962a4a7d96764b287b085b5b3d9ffae69cdefd1/yarl-1.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21242b4288a6d56f04ea193adde174b7e347ac46ce6bc84989ff7c1b1ecea84e", size = 339149 },
+    { url = "https://files.pythonhosted.org/packages/3c/95/d7fc301cc4661785967acc04f54a4a42d5124905e27db27bb578aac49b5c/yarl-1.20.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bea21cdae6c7eb02ba02a475f37463abfe0a01f5d7200121b03e605d6a0439f8", size = 333327 },
+    { url = "https://files.pythonhosted.org/packages/65/94/e21269718349582eee81efc5c1c08ee71c816bfc1585b77d0ec3f58089eb/yarl-1.20.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f8a891e4a22a89f5dde7862994485e19db246b70bb288d3ce73a34422e55b23", size = 326054 },
+    { url = "https://files.pythonhosted.org/packages/32/ae/8616d1f07853704523519f6131d21f092e567c5af93de7e3e94b38d7f065/yarl-1.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd803820d44c8853a109a34e3660e5a61beae12970da479cf44aa2954019bf70", size = 315035 },
+    { url = "https://files.pythonhosted.org/packages/48/aa/0ace06280861ef055855333707db5e49c6e3a08840a7ce62682259d0a6c0/yarl-1.20.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b982fa7f74c80d5c0c7b5b38f908971e513380a10fecea528091405f519b9ebb", size = 338962 },
+    { url = "https://files.pythonhosted.org/packages/20/52/1e9d0e6916f45a8fb50e6844f01cb34692455f1acd548606cbda8134cd1e/yarl-1.20.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:33f29ecfe0330c570d997bcf1afd304377f2e48f61447f37e846a6058a4d33b2", size = 335399 },
+    { url = "https://files.pythonhosted.org/packages/f2/65/60452df742952c630e82f394cd409de10610481d9043aa14c61bf846b7b1/yarl-1.20.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:835ab2cfc74d5eb4a6a528c57f05688099da41cf4957cf08cad38647e4a83b30", size = 338649 },
+    { url = "https://files.pythonhosted.org/packages/7b/f5/6cd4ff38dcde57a70f23719a838665ee17079640c77087404c3d34da6727/yarl-1.20.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:46b5e0ccf1943a9a6e766b2c2b8c732c55b34e28be57d8daa2b3c1d1d4009309", size = 358563 },
+    { url = "https://files.pythonhosted.org/packages/d1/90/c42eefd79d0d8222cb3227bdd51b640c0c1d0aa33fe4cc86c36eccba77d3/yarl-1.20.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:df47c55f7d74127d1b11251fe6397d84afdde0d53b90bedb46a23c0e534f9d24", size = 357609 },
+    { url = "https://files.pythonhosted.org/packages/03/c8/cea6b232cb4617514232e0f8a718153a95b5d82b5290711b201545825532/yarl-1.20.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:76d12524d05841276b0e22573f28d5fbcb67589836772ae9244d90dd7d66aa13", size = 350224 },
+    { url = "https://files.pythonhosted.org/packages/ce/a3/eaa0ab9712f1f3d01faf43cf6f1f7210ce4ea4a7e9b28b489a2261ca8db9/yarl-1.20.1-cp310-cp310-win32.whl", hash = "sha256:6c4fbf6b02d70e512d7ade4b1f998f237137f1417ab07ec06358ea04f69134f8", size = 81753 },
+    { url = "https://files.pythonhosted.org/packages/8f/34/e4abde70a9256465fe31c88ed02c3f8502b7b5dead693a4f350a06413f28/yarl-1.20.1-cp310-cp310-win_amd64.whl", hash = "sha256:aef6c4d69554d44b7f9d923245f8ad9a707d971e6209d51279196d8e8fe1ae16", size = 86817 },
+    { url = "https://files.pythonhosted.org/packages/b1/18/893b50efc2350e47a874c5c2d67e55a0ea5df91186b2a6f5ac52eff887cd/yarl-1.20.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:47ee6188fea634bdfaeb2cc420f5b3b17332e6225ce88149a17c413c77ff269e", size = 133833 },
+    { url = "https://files.pythonhosted.org/packages/89/ed/b8773448030e6fc47fa797f099ab9eab151a43a25717f9ac043844ad5ea3/yarl-1.20.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d0f6500f69e8402d513e5eedb77a4e1818691e8f45e6b687147963514d84b44b", size = 91070 },
+    { url = "https://files.pythonhosted.org/packages/e3/e3/409bd17b1e42619bf69f60e4f031ce1ccb29bd7380117a55529e76933464/yarl-1.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7a8900a42fcdaad568de58887c7b2f602962356908eedb7628eaf6021a6e435b", size = 89818 },
+    { url = "https://files.pythonhosted.org/packages/f8/77/64d8431a4d77c856eb2d82aa3de2ad6741365245a29b3a9543cd598ed8c5/yarl-1.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bad6d131fda8ef508b36be3ece16d0902e80b88ea7200f030a0f6c11d9e508d4", size = 347003 },
+    { url = "https://files.pythonhosted.org/packages/8d/d2/0c7e4def093dcef0bd9fa22d4d24b023788b0a33b8d0088b51aa51e21e99/yarl-1.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:df018d92fe22aaebb679a7f89fe0c0f368ec497e3dda6cb81a567610f04501f1", size = 336537 },
+    { url = "https://files.pythonhosted.org/packages/f0/f3/fc514f4b2cf02cb59d10cbfe228691d25929ce8f72a38db07d3febc3f706/yarl-1.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f969afbb0a9b63c18d0feecf0db09d164b7a44a053e78a7d05f5df163e43833", size = 362358 },
+    { url = "https://files.pythonhosted.org/packages/ea/6d/a313ac8d8391381ff9006ac05f1d4331cee3b1efaa833a53d12253733255/yarl-1.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:812303eb4aa98e302886ccda58d6b099e3576b1b9276161469c25803a8db277d", size = 357362 },
+    { url = "https://files.pythonhosted.org/packages/00/70/8f78a95d6935a70263d46caa3dd18e1f223cf2f2ff2037baa01a22bc5b22/yarl-1.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98c4a7d166635147924aa0bf9bfe8d8abad6fffa6102de9c99ea04a1376f91e8", size = 348979 },
+    { url = "https://files.pythonhosted.org/packages/cb/05/42773027968968f4f15143553970ee36ead27038d627f457cc44bbbeecf3/yarl-1.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12e768f966538e81e6e7550f9086a6236b16e26cd964cf4df35349970f3551cf", size = 337274 },
+    { url = "https://files.pythonhosted.org/packages/05/be/665634aa196954156741ea591d2f946f1b78ceee8bb8f28488bf28c0dd62/yarl-1.20.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fe41919b9d899661c5c28a8b4b0acf704510b88f27f0934ac7a7bebdd8938d5e", size = 363294 },
+    { url = "https://files.pythonhosted.org/packages/eb/90/73448401d36fa4e210ece5579895731f190d5119c4b66b43b52182e88cd5/yarl-1.20.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:8601bc010d1d7780592f3fc1bdc6c72e2b6466ea34569778422943e1a1f3c389", size = 358169 },
+    { url = "https://files.pythonhosted.org/packages/c3/b0/fce922d46dc1eb43c811f1889f7daa6001b27a4005587e94878570300881/yarl-1.20.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:daadbdc1f2a9033a2399c42646fbd46da7992e868a5fe9513860122d7fe7a73f", size = 362776 },
+    { url = "https://files.pythonhosted.org/packages/f1/0d/b172628fce039dae8977fd22caeff3eeebffd52e86060413f5673767c427/yarl-1.20.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:03aa1e041727cb438ca762628109ef1333498b122e4c76dd858d186a37cec845", size = 381341 },
+    { url = "https://files.pythonhosted.org/packages/6b/9b/5b886d7671f4580209e855974fe1cecec409aa4a89ea58b8f0560dc529b1/yarl-1.20.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:642980ef5e0fa1de5fa96d905c7e00cb2c47cb468bfcac5a18c58e27dbf8d8d1", size = 379988 },
+    { url = "https://files.pythonhosted.org/packages/73/be/75ef5fd0fcd8f083a5d13f78fd3f009528132a1f2a1d7c925c39fa20aa79/yarl-1.20.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:86971e2795584fe8c002356d3b97ef6c61862720eeff03db2a7c86b678d85b3e", size = 371113 },
+    { url = "https://files.pythonhosted.org/packages/50/4f/62faab3b479dfdcb741fe9e3f0323e2a7d5cd1ab2edc73221d57ad4834b2/yarl-1.20.1-cp311-cp311-win32.whl", hash = "sha256:597f40615b8d25812f14562699e287f0dcc035d25eb74da72cae043bb884d773", size = 81485 },
+    { url = "https://files.pythonhosted.org/packages/f0/09/d9c7942f8f05c32ec72cd5c8e041c8b29b5807328b68b4801ff2511d4d5e/yarl-1.20.1-cp311-cp311-win_amd64.whl", hash = "sha256:26ef53a9e726e61e9cd1cda6b478f17e350fb5800b4bd1cd9fe81c4d91cfeb2e", size = 86686 },
+    { url = "https://files.pythonhosted.org/packages/5f/9a/cb7fad7d73c69f296eda6815e4a2c7ed53fc70c2f136479a91c8e5fbdb6d/yarl-1.20.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdcc4cd244e58593a4379fe60fdee5ac0331f8eb70320a24d591a3be197b94a9", size = 133667 },
+    { url = "https://files.pythonhosted.org/packages/67/38/688577a1cb1e656e3971fb66a3492501c5a5df56d99722e57c98249e5b8a/yarl-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b29a2c385a5f5b9c7d9347e5812b6f7ab267193c62d282a540b4fc528c8a9d2a", size = 91025 },
+    { url = "https://files.pythonhosted.org/packages/50/ec/72991ae51febeb11a42813fc259f0d4c8e0507f2b74b5514618d8b640365/yarl-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1112ae8154186dfe2de4732197f59c05a83dc814849a5ced892b708033f40dc2", size = 89709 },
+    { url = "https://files.pythonhosted.org/packages/99/da/4d798025490e89426e9f976702e5f9482005c548c579bdae792a4c37769e/yarl-1.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90bbd29c4fe234233f7fa2b9b121fb63c321830e5d05b45153a2ca68f7d310ee", size = 352287 },
+    { url = "https://files.pythonhosted.org/packages/1a/26/54a15c6a567aac1c61b18aa0f4b8aa2e285a52d547d1be8bf48abe2b3991/yarl-1.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:680e19c7ce3710ac4cd964e90dad99bf9b5029372ba0c7cbfcd55e54d90ea819", size = 345429 },
+    { url = "https://files.pythonhosted.org/packages/d6/95/9dcf2386cb875b234353b93ec43e40219e14900e046bf6ac118f94b1e353/yarl-1.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a979218c1fdb4246a05efc2cc23859d47c89af463a90b99b7c56094daf25a16", size = 365429 },
+    { url = "https://files.pythonhosted.org/packages/91/b2/33a8750f6a4bc224242a635f5f2cff6d6ad5ba651f6edcccf721992c21a0/yarl-1.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:255b468adf57b4a7b65d8aad5b5138dce6a0752c139965711bdcb81bc370e1b6", size = 363862 },
+    { url = "https://files.pythonhosted.org/packages/98/28/3ab7acc5b51f4434b181b0cee8f1f4b77a65919700a355fb3617f9488874/yarl-1.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97d67108e79cfe22e2b430d80d7571ae57d19f17cda8bb967057ca8a7bf5bfd", size = 355616 },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f666894aa947a371724ec7cd2e5daa78ee8a777b21509b4252dd7bd15e29/yarl-1.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8570d998db4ddbfb9a590b185a0a33dbf8aafb831d07a5257b4ec9948df9cb0a", size = 339954 },
+    { url = "https://files.pythonhosted.org/packages/f1/81/5f466427e09773c04219d3450d7a1256138a010b6c9f0af2d48565e9ad13/yarl-1.20.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:97c75596019baae7c71ccf1d8cc4738bc08134060d0adfcbe5642f778d1dca38", size = 365575 },
+    { url = "https://files.pythonhosted.org/packages/2e/e3/e4b0ad8403e97e6c9972dd587388940a032f030ebec196ab81a3b8e94d31/yarl-1.20.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1c48912653e63aef91ff988c5432832692ac5a1d8f0fb8a33091520b5bbe19ef", size = 365061 },
+    { url = "https://files.pythonhosted.org/packages/ac/99/b8a142e79eb86c926f9f06452eb13ecb1bb5713bd01dc0038faf5452e544/yarl-1.20.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4c3ae28f3ae1563c50f3d37f064ddb1511ecc1d5584e88c6b7c63cf7702a6d5f", size = 364142 },
+    { url = "https://files.pythonhosted.org/packages/34/f2/08ed34a4a506d82a1a3e5bab99ccd930a040f9b6449e9fd050320e45845c/yarl-1.20.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c5e9642f27036283550f5f57dc6156c51084b458570b9d0d96100c8bebb186a8", size = 381894 },
+    { url = "https://files.pythonhosted.org/packages/92/f8/9a3fbf0968eac704f681726eff595dce9b49c8a25cd92bf83df209668285/yarl-1.20.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2c26b0c49220d5799f7b22c6838409ee9bc58ee5c95361a4d7831f03cc225b5a", size = 383378 },
+    { url = "https://files.pythonhosted.org/packages/af/85/9363f77bdfa1e4d690957cd39d192c4cacd1c58965df0470a4905253b54f/yarl-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564ab3d517e3d01c408c67f2e5247aad4019dcf1969982aba3974b4093279004", size = 374069 },
+    { url = "https://files.pythonhosted.org/packages/35/99/9918c8739ba271dcd935400cff8b32e3cd319eaf02fcd023d5dcd487a7c8/yarl-1.20.1-cp312-cp312-win32.whl", hash = "sha256:daea0d313868da1cf2fac6b2d3a25c6e3a9e879483244be38c8e6a41f1d876a5", size = 81249 },
+    { url = "https://files.pythonhosted.org/packages/eb/83/5d9092950565481b413b31a23e75dd3418ff0a277d6e0abf3729d4d1ce25/yarl-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:48ea7d7f9be0487339828a4de0360d7ce0efc06524a48e1810f945c45b813698", size = 86710 },
+    { url = "https://files.pythonhosted.org/packages/8a/e1/2411b6d7f769a07687acee88a062af5833cf1966b7266f3d8dfb3d3dc7d3/yarl-1.20.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b5ff0fbb7c9f1b1b5ab53330acbfc5247893069e7716840c8e7d5bb7355038a", size = 131811 },
+    { url = "https://files.pythonhosted.org/packages/b2/27/584394e1cb76fb771371770eccad35de400e7b434ce3142c2dd27392c968/yarl-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:14f326acd845c2b2e2eb38fb1346c94f7f3b01a4f5c788f8144f9b630bfff9a3", size = 90078 },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/3246ae92d4049099f52d9b0fe3486e3b500e29b7ea872d0f152966fc209d/yarl-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f60e4ad5db23f0b96e49c018596707c3ae89f5d0bd97f0ad3684bcbad899f1e7", size = 88748 },
+    { url = "https://files.pythonhosted.org/packages/a3/25/35afe384e31115a1a801fbcf84012d7a066d89035befae7c5d4284df1e03/yarl-1.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49bdd1b8e00ce57e68ba51916e4bb04461746e794e7c4d4bbc42ba2f18297691", size = 349595 },
+    { url = "https://files.pythonhosted.org/packages/28/2d/8aca6cb2cabc8f12efcb82749b9cefecbccfc7b0384e56cd71058ccee433/yarl-1.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:66252d780b45189975abfed839616e8fd2dbacbdc262105ad7742c6ae58f3e31", size = 342616 },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/1312633d16b31acf0098d30440ca855e3492d66623dafb8e25b03d00c3da/yarl-1.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59174e7332f5d153d8f7452a102b103e2e74035ad085f404df2e40e663a22b28", size = 361324 },
+    { url = "https://files.pythonhosted.org/packages/bc/a0/688cc99463f12f7669eec7c8acc71ef56a1521b99eab7cd3abb75af887b0/yarl-1.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e3968ec7d92a0c0f9ac34d5ecfd03869ec0cab0697c91a45db3fbbd95fe1b653", size = 359676 },
+    { url = "https://files.pythonhosted.org/packages/af/44/46407d7f7a56e9a85a4c207724c9f2c545c060380718eea9088f222ba697/yarl-1.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1a4fbb50e14396ba3d375f68bfe02215d8e7bc3ec49da8341fe3157f59d2ff5", size = 352614 },
+    { url = "https://files.pythonhosted.org/packages/b1/91/31163295e82b8d5485d31d9cf7754d973d41915cadce070491778d9c9825/yarl-1.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11a62c839c3a8eac2410e951301309426f368388ff2f33799052787035793b02", size = 336766 },
+    { url = "https://files.pythonhosted.org/packages/b4/8e/c41a5bc482121f51c083c4c2bcd16b9e01e1cf8729e380273a952513a21f/yarl-1.20.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:041eaa14f73ff5a8986b4388ac6bb43a77f2ea09bf1913df7a35d4646db69e53", size = 364615 },
+    { url = "https://files.pythonhosted.org/packages/e3/5b/61a3b054238d33d70ea06ebba7e58597891b71c699e247df35cc984ab393/yarl-1.20.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:377fae2fef158e8fd9d60b4c8751387b8d1fb121d3d0b8e9b0be07d1b41e83dc", size = 360982 },
+    { url = "https://files.pythonhosted.org/packages/df/a3/6a72fb83f8d478cb201d14927bc8040af901811a88e0ff2da7842dd0ed19/yarl-1.20.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1c92f4390e407513f619d49319023664643d3339bd5e5a56a3bebe01bc67ec04", size = 369792 },
+    { url = "https://files.pythonhosted.org/packages/7c/af/4cc3c36dfc7c077f8dedb561eb21f69e1e9f2456b91b593882b0b18c19dc/yarl-1.20.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d25ddcf954df1754ab0f86bb696af765c5bfaba39b74095f27eececa049ef9a4", size = 382049 },
+    { url = "https://files.pythonhosted.org/packages/19/3a/e54e2c4752160115183a66dc9ee75a153f81f3ab2ba4bf79c3c53b33de34/yarl-1.20.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:909313577e9619dcff8c31a0ea2aa0a2a828341d92673015456b3ae492e7317b", size = 384774 },
+    { url = "https://files.pythonhosted.org/packages/9c/20/200ae86dabfca89060ec6447649f219b4cbd94531e425e50d57e5f5ac330/yarl-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:793fd0580cb9664548c6b83c63b43c477212c0260891ddf86809e1c06c8b08f1", size = 374252 },
+    { url = "https://files.pythonhosted.org/packages/83/75/11ee332f2f516b3d094e89448da73d557687f7d137d5a0f48c40ff211487/yarl-1.20.1-cp313-cp313-win32.whl", hash = "sha256:468f6e40285de5a5b3c44981ca3a319a4b208ccc07d526b20b12aeedcfa654b7", size = 81198 },
+    { url = "https://files.pythonhosted.org/packages/ba/ba/39b1ecbf51620b40ab402b0fc817f0ff750f6d92712b44689c2c215be89d/yarl-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:495b4ef2fea40596bfc0affe3837411d6aa3371abcf31aac0ccc4bdd64d4ef5c", size = 86346 },
+    { url = "https://files.pythonhosted.org/packages/43/c7/669c52519dca4c95153c8ad96dd123c79f354a376346b198f438e56ffeb4/yarl-1.20.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f60233b98423aab21d249a30eb27c389c14929f47be8430efa7dbd91493a729d", size = 138826 },
+    { url = "https://files.pythonhosted.org/packages/6a/42/fc0053719b44f6ad04a75d7f05e0e9674d45ef62f2d9ad2c1163e5c05827/yarl-1.20.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6f3eff4cc3f03d650d8755c6eefc844edde99d641d0dcf4da3ab27141a5f8ddf", size = 93217 },
+    { url = "https://files.pythonhosted.org/packages/4f/7f/fa59c4c27e2a076bba0d959386e26eba77eb52ea4a0aac48e3515c186b4c/yarl-1.20.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:69ff8439d8ba832d6bed88af2c2b3445977eba9a4588b787b32945871c2444e3", size = 92700 },
+    { url = "https://files.pythonhosted.org/packages/2f/d4/062b2f48e7c93481e88eff97a6312dca15ea200e959f23e96d8ab898c5b8/yarl-1.20.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cf34efa60eb81dd2645a2e13e00bb98b76c35ab5061a3989c7a70f78c85006d", size = 347644 },
+    { url = "https://files.pythonhosted.org/packages/89/47/78b7f40d13c8f62b499cc702fdf69e090455518ae544c00a3bf4afc9fc77/yarl-1.20.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8e0fe9364ad0fddab2688ce72cb7a8e61ea42eff3c7caeeb83874a5d479c896c", size = 323452 },
+    { url = "https://files.pythonhosted.org/packages/eb/2b/490d3b2dc66f52987d4ee0d3090a147ea67732ce6b4d61e362c1846d0d32/yarl-1.20.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f64fbf81878ba914562c672024089e3401974a39767747691c65080a67b18c1", size = 346378 },
+    { url = "https://files.pythonhosted.org/packages/66/ad/775da9c8a94ce925d1537f939a4f17d782efef1f973039d821cbe4bcc211/yarl-1.20.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6342d643bf9a1de97e512e45e4b9560a043347e779a173250824f8b254bd5ce", size = 353261 },
+    { url = "https://files.pythonhosted.org/packages/4b/23/0ed0922b47a4f5c6eb9065d5ff1e459747226ddce5c6a4c111e728c9f701/yarl-1.20.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56dac5f452ed25eef0f6e3c6a066c6ab68971d96a9fb441791cad0efba6140d3", size = 335987 },
+    { url = "https://files.pythonhosted.org/packages/3e/49/bc728a7fe7d0e9336e2b78f0958a2d6b288ba89f25a1762407a222bf53c3/yarl-1.20.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7d7f497126d65e2cad8dc5f97d34c27b19199b6414a40cb36b52f41b79014be", size = 329361 },
+    { url = "https://files.pythonhosted.org/packages/93/8f/b811b9d1f617c83c907e7082a76e2b92b655400e61730cd61a1f67178393/yarl-1.20.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:67e708dfb8e78d8a19169818eeb5c7a80717562de9051bf2413aca8e3696bf16", size = 346460 },
+    { url = "https://files.pythonhosted.org/packages/70/fd/af94f04f275f95da2c3b8b5e1d49e3e79f1ed8b6ceb0f1664cbd902773ff/yarl-1.20.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:595c07bc79af2494365cc96ddeb772f76272364ef7c80fb892ef9d0649586513", size = 334486 },
+    { url = "https://files.pythonhosted.org/packages/84/65/04c62e82704e7dd0a9b3f61dbaa8447f8507655fd16c51da0637b39b2910/yarl-1.20.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7bdd2f80f4a7df852ab9ab49484a4dee8030023aa536df41f2d922fd57bf023f", size = 342219 },
+    { url = "https://files.pythonhosted.org/packages/91/95/459ca62eb958381b342d94ab9a4b6aec1ddec1f7057c487e926f03c06d30/yarl-1.20.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c03bfebc4ae8d862f853a9757199677ab74ec25424d0ebd68a0027e9c639a390", size = 350693 },
+    { url = "https://files.pythonhosted.org/packages/a6/00/d393e82dd955ad20617abc546a8f1aee40534d599ff555ea053d0ec9bf03/yarl-1.20.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:344d1103e9c1523f32a5ed704d576172d2cabed3122ea90b1d4e11fe17c66458", size = 355803 },
+    { url = "https://files.pythonhosted.org/packages/9e/ed/c5fb04869b99b717985e244fd93029c7a8e8febdfcffa06093e32d7d44e7/yarl-1.20.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:88cab98aa4e13e1ade8c141daeedd300a4603b7132819c484841bb7af3edce9e", size = 341709 },
+    { url = "https://files.pythonhosted.org/packages/24/fd/725b8e73ac2a50e78a4534ac43c6addf5c1c2d65380dd48a9169cc6739a9/yarl-1.20.1-cp313-cp313t-win32.whl", hash = "sha256:b121ff6a7cbd4abc28985b6028235491941b9fe8fe226e6fdc539c977ea1739d", size = 86591 },
+    { url = "https://files.pythonhosted.org/packages/94/c3/b2e9f38bc3e11191981d57ea08cab2166e74ea770024a646617c9cddd9f6/yarl-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:541d050a355bbbc27e55d906bc91cb6fe42f96c01413dd0f4ed5a5240513874f", size = 93003 },
+    { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542 },
+]
+
+[[package]]
+name = "youtube-transcript-api"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e5/226a09b9ca49136f901a969fd65bcd055eaa980fd04ac065dac4741e6b00/youtube_transcript_api-1.1.1.tar.gz", hash = "sha256:2e1162d45ece14223a58a4a39176c464fdd33d5ebdd6def18ebb038dea62f667", size = 470360 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/8a/b942a230084045da4a255bbebca97693569535670c0a23c09096881b2846/youtube_transcript_api-1.1.1-py3-none-any.whl", hash = "sha256:a438a824d67c0885855047e2b38993abdd4f59b69a983cf27b50a06c9d564064", size = 485906 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🎨 Major Release: Web UI and Multi-Content Support

This PR introduces a comprehensive web interface and enhanced content handling capabilities for podcast-creator v0.3.0.

## 🚀 New Features

### Web Interface (`podcast-creator ui`)
- **Complete Streamlit Interface**: Launch with `podcast-creator ui`
- **Automatic Setup**: Dependency checking and initialization
- **Profile Management**: Visual CRUD operations for speakers and episodes
- **Voice Selection**: Provider-specific dropdown menus
- **Episode Library**: Audio playback, transcript viewing, downloads
- **Multi-Content Generation**: Combine text, files, and URLs

### Multi-Content Support
- **Structured Content Arrays**: Pass multiple content sources to AI prompts
- **Enhanced Templates**: Updated Jinja templates to handle content arrays
- **Backward Compatibility**: Still accepts single string content

### Provider Integration
- **Environment-Based Availability**: Shows only available AI providers
- **Voice Provider Integration**: Dropdown selection for TTS voices
- **Error Handling**: Comprehensive error recovery throughout

## 🔧 Technical Changes

### API Changes
- `create_podcast()` now accepts `Union[str, List[Dict]]` for content parameter
- Updated prompt templates in `outline.jinja` and `transcript.jinja`
- Enhanced PodcastState to support both content formats

### Dependencies Added
- `streamlit>=1.46.1` - Web interface framework
- `nest-asyncio>=1.6.0` - Async compatibility
- `pydub>=0.25.1` - Audio metadata
- `requests>=2.32.4` - HTTP requests
- `content-core>=1.2.3` - Content extraction

### Package Structure
- Bundled Streamlit app in `resources/streamlit_app/`
- Complete utility modules for profile and episode management
- Updated CLI with new `ui` command

## 📖 Documentation Updates
- Updated main README with web interface instructions
- Added comprehensive Streamlit app README
- Enhanced CLI command documentation
- Updated feature lists and examples

## 🎯 User Experience

### Before
```bash
# Complex setup required
mkdir my_project && cd my_project
podcast-creator init
# Manual profile management via JSON files
# CLI-only podcast generation
```

### After
```bash
# One command setup and launch
podcast-creator ui
# Visual profile management
# Multi-content podcast generation
# Built-in episode library
```

## 🧪 Testing

- [x] CLI command works with dependency checking
- [x] Automatic initialization when missing files
- [x] Bundled app extraction and execution
- [x] Multi-content array processing
- [x] Voice selection integration
- [x] Provider availability checking
- [x] Episode library functionality

## 🔄 Migration Guide

Existing code continues to work unchanged:
```python
# This still works exactly the same
result = await create_podcast(
    content="Your content...",
    episode_profile="tech_discussion",
    episode_name="my_podcast",
    output_dir="output"
)
```

New multi-content capability:
```python
# New: structured content arrays
content_pieces = [
    {"title": "Article", "content": "...", "type": "text"},
    {"title": "Report", "content": "...", "type": "file"}
]

result = await create_podcast(
    content=content_pieces,  # Pass array instead of string
    episode_profile="tech_discussion",
    episode_name="my_podcast",
    output_dir="output"
)
```

## 📦 Release Notes

### v0.3.0 - Web Interface & Multi-Content
- 🎨 **New**: Complete web interface via `podcast-creator ui`
- 📊 **New**: Multi-content support with structured arrays
- 🎙️ **Enhanced**: Voice selection with provider-specific dropdowns
- 🔧 **Enhanced**: Provider availability checking
- 📚 **New**: Built-in episode library with playback
- 📤 **New**: Profile import/export functionality
- 🛠️ **Enhanced**: Automatic dependency management
- 📖 **Updated**: Comprehensive documentation

This release transforms podcast-creator from a library into a complete podcast creation studio while maintaining full backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)