### PR TITLE
fix: add contents write permission to tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -12,6 +12,8 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'yes'
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the Create Tag workflow by adding explicit `contents: write` permission.

The workflow was failing with 403 error because GitHub Actions bot didn't have permission to push tags.

This is a quick fix to enable the manual tag creation feature.