### PR TITLE
fix: include JSON parsing in retry scope for LLM calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-02-17
+
+### Fixed
+- Retry now covers both LLM call and JSON parsing — previously only the `ainvoke()` call was retried, so invalid JSON responses from the LLM were not retried
+
 ## [0.11.1] - 2026-02-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "podcast-creator"
-version = "0.11.1"
+version = "0.11.2"
 license = "MIT"
 description = "AI-powered podcast generation tool that creates conversational audio content from text sources"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -3082,7 +3082,7 @@ wheels = [
 
 [[package]]
 name = "podcast-creator"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },


### PR DESCRIPTION
## Summary

- Retry wrapper in outline and transcript nodes now covers the full cycle: LLM `ainvoke()` + response extraction + JSON parsing
- Previously only `ainvoke()` was retried, so `OutputParserException` from invalid JSON was not retried
- Bumps version to 0.11.2

## Test plan

- [x] All 93 tests pass
- [ ] Manual smoke test: trigger an LLM that occasionally returns invalid JSON and verify it retries