### PR TITLE
fix: recover consistent transcript speaker labels

### DIFF
--- a/src/podcast_creator/core.py
+++ b/src/podcast_creator/core.py
@@ -159,6 +159,13 @@ class Segment(BaseModel):
 class Outline(BaseModel):
     segments: list[Segment] = Field(..., description="List of segments")
 
+    @model_validator(mode="before")
+    @classmethod
+    def unwrap_outline(cls, value):
+        if isinstance(value, dict) and isinstance(value.get("outline"), dict):
+            return value["outline"]
+        return value
+
     def model_dump(self, **kwargs) -> Dict[str, Any]:
         return {"segments": [segment.model_dump(**kwargs) for segment in self.segments]}
 

--- a/src/podcast_creator/core.py
+++ b/src/podcast_creator/core.py
@@ -1,5 +1,6 @@
 import json
 import re
+import subprocess
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Tuple, Union
@@ -11,6 +12,33 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Compile regex pattern once for better performance
 THINK_PATTERN = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+
+
+def trim_trailing_silence(file_path: Path) -> None:
+    """Remove generator padding while preserving speech and in-clip pauses."""
+    from imageio_ffmpeg import get_ffmpeg_exe
+
+    trimmed_path = file_path.with_suffix(".trimmed.mp3")
+    try:
+        subprocess.run(
+            [
+                get_ffmpeg_exe(),
+                "-y",
+                "-i",
+                str(file_path),
+                "-af",
+                "areverse,silenceremove=start_periods=1:start_duration=1:start_threshold=-45dB:start_silence=0.25,areverse",
+                "-codec:a",
+                "libmp3lame",
+                str(trimmed_path),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        trimmed_path.replace(file_path)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        logger.warning(f"Could not trim trailing silence from {file_path}: {exc}")
+        trimmed_path.unlink(missing_ok=True)
 
 
 def parse_thinking_content(content: str) -> Tuple[str, str]:
@@ -363,6 +391,7 @@ async def combine_audio_files(
 
         try:
             if file_path.exists() and file_path.is_file():
+                trim_trailing_silence(file_path)
                 clips.append(AudioFileClip(str(file_path)))
                 valid_clips.append(clips[-1])  # Keep track of valid clips for later
             else:

--- a/src/podcast_creator/core.py
+++ b/src/podcast_creator/core.py
@@ -58,7 +58,7 @@ def parse_thinking_content(content: str) -> Tuple[str, str]:
     if "<think>" in cleaned_content:
         think_idx = cleaned_content.index("<think>")
         before = cleaned_content[:think_idx]
-        after = cleaned_content[think_idx + len("<think>"):]
+        after = cleaned_content[think_idx + len("<think>") :]
 
         # Find valid JSON in the remaining content using raw_decode,
         # which can parse JSON starting at any position and ignores trailing text.
@@ -152,7 +152,7 @@ class Segment(BaseModel):
     name: str = Field(..., description="Name of the segment")
     description: str = Field(..., description="Description of the segment")
     size: Literal["short", "medium", "long"] = Field(
-        default="medium", description="Size of the segment"
+        ..., description="Size of the segment"
     )
 
 
@@ -168,6 +168,18 @@ class Outline(BaseModel):
 
     def model_dump(self, **kwargs) -> Dict[str, Any]:
         return {"segments": [segment.model_dump(**kwargs) for segment in self.segments]}
+
+
+def create_outline_parser(num_segments: int) -> PydanticOutputParser:
+    class ExactOutline(Outline):
+        segments: list[Segment] = Field(
+            ...,
+            min_length=num_segments,
+            max_length=num_segments,
+            description="List of segments",
+        )
+
+    return PydanticOutputParser(pydantic_object=ExactOutline)
 
 
 class Dialogue(BaseModel):
@@ -221,19 +233,25 @@ def create_validated_transcript_parser(valid_speaker_names: List[str]):
 
         @model_validator(mode="after")
         def canonicalize_speakers(self):
-            labels = list(dict.fromkeys(dialogue.speaker for dialogue in self.transcript))
+            labels = list(
+                dict.fromkeys(dialogue.speaker for dialogue in self.transcript)
+            )
             canonical = {}
             for label in labels:
                 matches = [
-                    name for name in valid_speaker_names
-                    if label == name or label.casefold()
+                    name
+                    for name in valid_speaker_names
+                    if label == name
+                    or label.casefold()
                     in {part.rstrip(".").casefold() for part in name.split()}
                 ]
                 if len(matches) == 1:
                     canonical[label] = matches[0]
 
             unknown = [label for label in labels if label not in canonical]
-            remaining = [name for name in valid_speaker_names if name not in canonical.values()]
+            remaining = [
+                name for name in valid_speaker_names if name not in canonical.values()
+            ]
             if unknown and (len(remaining) == 1 or len(unknown) == len(remaining)):
                 canonical.update(zip(unknown, remaining))
             elif unknown:
@@ -255,16 +273,31 @@ def create_validated_transcript_parser(valid_speaker_names: List[str]):
     return PydanticOutputParser(pydantic_object=ValidatedTranscript)
 
 
+def create_validated_transcript_schema(
+    valid_speaker_names: List[str],
+) -> type[BaseModel]:
+    SpeakerName = Literal.__getitem__(tuple(valid_speaker_names))
+
+    class StrictDialogue(BaseModel):
+        speaker: SpeakerName = Field(..., description="Speaker name")
+        dialogue: str = Field(..., description="Dialogue")
+
+    class StrictTranscript(BaseModel):
+        transcript: list[StrictDialogue] = Field(..., description="Transcript")
+
+    return StrictTranscript
+
+
 outline_parser = PydanticOutputParser(pydantic_object=Outline)
 transcript_parser = PydanticOutputParser(pydantic_object=Transcript)
 
 
-def get_outline_prompter():
+def get_outline_prompter(parser: PydanticOutputParser = outline_parser):
     """Get outline prompter with configuration support."""
     from .config import ConfigurationManager
 
     config_manager = ConfigurationManager()
-    return config_manager.get_template_prompter("outline", parser=outline_parser)
+    return config_manager.get_template_prompter("outline", parser=parser)
 
 
 def get_transcript_prompter():

--- a/src/podcast_creator/core.py
+++ b/src/podcast_creator/core.py
@@ -19,10 +19,11 @@ def trim_trailing_silence(file_path: Path) -> None:
     from imageio_ffmpeg import get_ffmpeg_exe
 
     trimmed_path = file_path.with_suffix(".trimmed.mp3")
+    ffmpeg = get_ffmpeg_exe()
     try:
         subprocess.run(
             [
-                get_ffmpeg_exe(),
+                ffmpeg,
                 "-y",
                 "-i",
                 str(file_path),
@@ -32,6 +33,11 @@ def trim_trailing_silence(file_path: Path) -> None:
                 "libmp3lame",
                 str(trimmed_path),
             ],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [ffmpeg, "-v", "error", "-i", str(trimmed_path), "-f", "null", "-"],
             check=True,
             capture_output=True,
         )

--- a/src/podcast_creator/core.py
+++ b/src/podcast_creator/core.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Literal, Tuple, Union
 from langchain_core.output_parsers.pydantic import PydanticOutputParser
 from loguru import logger
 from moviepy import AudioFileClip, concatenate_audioclips
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Compile regex pattern once for better performance
 THINK_PATTERN = re.compile(r"<think>(.*?)</think>", re.DOTALL)
@@ -207,17 +207,36 @@ def create_validated_transcript_parser(valid_speaker_names: List[str]):
         def validate_speaker_name(cls, v):
             if not v or len(v.strip()) == 0:
                 raise ValueError("Speaker name cannot be empty")
-
-            cleaned_name = v.strip()
-            if cleaned_name not in valid_speaker_names:
-                raise ValueError(
-                    f"Invalid speaker name '{cleaned_name}'. Must be one of: {', '.join(valid_speaker_names)}"
-                )
-
-            return cleaned_name
+            return v.strip()
 
     class ValidatedTranscript(BaseModel):
         transcript: list[ValidatedDialogue] = Field(..., description="Transcript")
+
+        @model_validator(mode="after")
+        def canonicalize_speakers(self):
+            labels = list(dict.fromkeys(dialogue.speaker for dialogue in self.transcript))
+            canonical = {}
+            for label in labels:
+                matches = [
+                    name for name in valid_speaker_names
+                    if label == name or label.casefold()
+                    in {part.rstrip(".").casefold() for part in name.split()}
+                ]
+                if len(matches) == 1:
+                    canonical[label] = matches[0]
+
+            unknown = [label for label in labels if label not in canonical]
+            remaining = [name for name in valid_speaker_names if name not in canonical.values()]
+            if unknown and (len(remaining) == 1 or len(unknown) == len(remaining)):
+                canonical.update(zip(unknown, remaining))
+            elif unknown:
+                raise ValueError(
+                    f"Invalid speaker names: {', '.join(unknown)}. Must be one of: {', '.join(valid_speaker_names)}"
+                )
+
+            for dialogue in self.transcript:
+                dialogue.speaker = canonical[dialogue.speaker]
+            return self
 
         def model_dump(self, **kwargs) -> Dict[str, Any]:
             return {

--- a/src/podcast_creator/nodes.py
+++ b/src/podcast_creator/nodes.py
@@ -11,11 +11,12 @@ from .core import (
     Dialogue,
     clean_thinking_content,
     combine_audio_files,
+    create_outline_parser,
     create_validated_transcript_parser,
+    create_validated_transcript_schema,
     extract_text_content,
     get_outline_prompter,
     get_transcript_prompter,
-    outline_parser,
 )
 from .retry import create_retry_decorator, get_retry_config
 from .state import PodcastState
@@ -29,12 +30,18 @@ async def generate_outline_node(state: PodcastState, config: RunnableConfig) -> 
     outline_provider = configurable.get("outline_provider", "openai")
     outline_model_name = configurable.get("outline_model", "gpt-4o-mini")
     outline_config = configurable.get("outline_config") or {}
+    outline_parser = create_outline_parser(state["num_segments"])
 
     # Create outline model
     merged_config = {
         "max_tokens": 3000,
-        "structured": {"type": "json"},
         **outline_config,
+        "structured": {
+            "type": "json_schema",
+            "schema": outline_parser.pydantic_object,
+            "name": "podcast_outline",
+            "strict": True,
+        },
     }
     outline_model = AIFactory.create_language(
         outline_provider,
@@ -54,18 +61,16 @@ async def generate_outline_node(state: PodcastState, config: RunnableConfig) -> 
         return outline_parser.invoke(content)
 
     # Generate outline
-    outline_prompt = get_outline_prompter()
-    outline_prompt_text = outline_prompt.render(
-        {
-            "briefing": state["briefing"],
-            "num_segments": state["num_segments"],
-            "context": state["content"],
-            "speakers": state["speaker_profile"].speakers
-            if state["speaker_profile"]
-            else [],
-            "language": state.get("language"),
-        }
-    )
+    outline_prompt = get_outline_prompter(parser=outline_parser)
+    outline_prompt_text = outline_prompt.render({
+        "briefing": state["briefing"],
+        "num_segments": state["num_segments"],
+        "context": state["content"],
+        "speakers": state["speaker_profile"].speakers
+        if state["speaker_profile"]
+        else [],
+        "language": state.get("language"),
+    })
 
     outline_result = await _invoke_and_parse(outline_prompt_text)
 
@@ -86,23 +91,29 @@ async def generate_transcript_node(state: PodcastState, config: RunnableConfig) 
     transcript_model_name: str = configurable.get("transcript_model", "gpt-4o-mini")
     transcript_config = configurable.get("transcript_config") or {}
 
+    # Create validated transcript parser
+    speaker_profile = state["speaker_profile"]
+    assert speaker_profile is not None, "speaker_profile must be provided"
+    speaker_names = speaker_profile.get_speaker_names()
+    validated_transcript_parser = create_validated_transcript_parser(speaker_names)
+    transcript_schema = create_validated_transcript_schema(speaker_names)
+
     # Create transcript model
     merged_config = {
         "max_tokens": 5000,
-        "structured": {"type": "json"},
         **transcript_config,
+        "structured": {
+            "type": "json_schema",
+            "schema": transcript_schema,
+            "name": "podcast_transcript",
+            "strict": True,
+        },
     }
     transcript_model = AIFactory.create_language(
         transcript_provider,
         transcript_model_name,
         config=merged_config,
     ).to_langchain()
-
-    # Create validated transcript parser
-    speaker_profile = state["speaker_profile"]
-    assert speaker_profile is not None, "speaker_profile must be provided"
-    speaker_names = speaker_profile.get_speaker_names()
-    validated_transcript_parser = create_validated_transcript_parser(speaker_names)
 
     # Build retry decorator from configurable settings
     retry_cfg = get_retry_config(configurable)
@@ -126,15 +137,12 @@ async def generate_transcript_node(state: PodcastState, config: RunnableConfig) 
         )
 
         is_final = i == len(outline.segments) - 1
-        turns = 3 if segment.size == "short" else 6 if segment.size == "medium" else 10
-
         data = {
             "briefing": state["briefing"],
             "outline": outline,
             "context": state["content"],
             "segment": segment,
             "is_final": is_final,
-            "turns": turns,
             "speakers": speaker_profile.speakers,
             "speaker_names": speaker_names,
             "transcript": transcript,
@@ -220,7 +228,9 @@ async def generate_all_audio_node(state: PodcastState, config: RunnableConfig) -
                 "tts_provider": speaker.tts_provider or tts_provider,
                 "tts_model": speaker.tts_model or tts_model,
                 "voices": voices,
-                "tts_config": speaker.tts_config if speaker.tts_config is not None else tts_config,
+                "tts_config": speaker.tts_config
+                if speaker.tts_config is not None
+                else tts_config,
             }
             task = _generate_clip(dialogue_info)
             batch_tasks.append(task)

--- a/src/podcast_creator/nodes.py
+++ b/src/podcast_creator/nodes.py
@@ -263,6 +263,7 @@ async def generate_single_audio_clip(dialogue_info: Dict) -> Path:
     # Extract named params from tts_config, pass rest as kwargs
     api_key = tts_config.pop("api_key", None)
     base_url = tts_config.pop("base_url", None)
+    max_tokens = tts_config.pop("max_tokens", None)
 
     # Create TTS model
     tts_model = AIFactory.create_text_to_speech(
@@ -271,7 +272,10 @@ async def generate_single_audio_clip(dialogue_info: Dict) -> Path:
 
     # Generate audio
     await tts_model.agenerate_speech(
-        text=dialogue.dialogue, voice=voices[dialogue.speaker], output_file=clip_path
+        text=dialogue.dialogue,
+        voice=voices[dialogue.speaker],
+        output_file=clip_path,
+        **({"max_tokens": max_tokens} if max_tokens is not None else {}),
     )
 
     logger.info(f"Generated audio clip: {clip_path}")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ Tests for core utility functions
 
 from podcast_creator.core import (
     clean_thinking_content,
+    create_validated_transcript_parser,
     extract_text_content,
     parse_thinking_content,
 )
@@ -197,3 +198,34 @@ class TestParseThinkingContent:
         import json
         parsed = json.loads(cleaned)
         assert len(parsed["transcript"]) == 2
+
+
+class TestValidatedTranscriptParser:
+    def test_canonicalizes_a_complete_replacement_cast(self):
+        parser = create_validated_transcript_parser(
+            ["Dr. Alex Chen", "Jamie Rodriguez"]
+        )
+
+        transcript = parser.parse(
+            '{"transcript": ['
+            '{"speaker": "Alex", "dialogue": "Welcome."}, '
+            '{"speaker": "Jordan", "dialogue": "Thanks."}'
+            ']}'
+        )
+
+        assert [dialogue.speaker for dialogue in transcript.transcript] == [
+            "Dr. Alex Chen",
+            "Jamie Rodriguez",
+        ]
+
+    def test_rejects_an_ambiguous_replacement_speaker(self):
+        parser = create_validated_transcript_parser(
+            ["Dr. Alex Chen", "Jamie Rodriguez"]
+        )
+
+        import pytest
+
+        with pytest.raises(Exception, match="Invalid speaker names: Sam"):
+            parser.parse(
+                '{"transcript": [{"speaker": "Sam", "dialogue": "Hello."}]}'
+            )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,11 +3,21 @@ Tests for core utility functions
 """
 
 from podcast_creator.core import (
+    outline_parser,
     clean_thinking_content,
     create_validated_transcript_parser,
     extract_text_content,
     parse_thinking_content,
 )
+
+
+class TestOutlineParser:
+    def test_accepts_outline_wrapper(self):
+        outline = outline_parser.parse(
+            '{"outline": {"segments": [{"name": "One", "description": "First", "size": "short"}]}}'
+        )
+
+        assert outline.segments[0].name == "One"
 
 
 class TestExtractTextContent:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,7 +22,8 @@ class TestTrailingSilenceTrim:
         clip.write_bytes(b"padded")
 
         def fake_run(command, **_):
-            Path(command[-1]).write_bytes(b"trimmed")
+            if command[-1] != "-":
+                Path(command[-1]).write_bytes(b"trimmed")
 
         monkeypatch.setattr("podcast_creator.core.subprocess.run", fake_run)
         monkeypatch.setattr("imageio_ffmpeg.get_ffmpeg_exe", lambda: "ffmpeg")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,8 @@ Tests for core utility functions
 """
 
 from podcast_creator.core import (
+    create_outline_parser,
+    create_validated_transcript_schema,
     outline_parser,
     clean_thinking_content,
     create_validated_transcript_parser,
@@ -19,6 +21,34 @@ class TestOutlineParser:
 
         assert outline.segments[0].name == "One"
 
+    def test_requires_the_selected_segment_count_and_size(self):
+        parser = create_outline_parser(2)
+
+        assert (
+            len(
+                parser.parse("""{"segments": [
+            {"name": "One", "description": "First", "size": "short"},
+            {"name": "Two", "description": "Second", "size": "long"}
+        ]}""").segments
+            )
+            == 2
+        )
+
+        import pytest
+
+        with pytest.raises(Exception):
+            parser.parse(
+                '{"segments": [{"name": "One", "description": "First", "size": "short"}]}'
+            )
+
+        with pytest.raises(Exception):
+            parser.parse(
+                """{"segments": [
+                    {"name": "One", "description": "First"},
+                    {"name": "Two", "description": "Second", "size": "long"}
+                ]}"""
+            )
+
 
 class TestExtractTextContent:
     """Tests for extract_text_content function"""
@@ -29,9 +59,7 @@ class TestExtractTextContent:
 
     def test_gemini_format(self):
         """Structured list with dict parts containing 'text' key (Gemini-style)"""
-        content = [
-            {"type": "text", "text": "hello world", "extras": {"some": "data"}}
-        ]
+        content = [{"type": "text", "text": "hello world", "extras": {"some": "data"}}]
         assert extract_text_content(content) == "hello world"
 
     def test_gemini_format_multiple_parts(self):
@@ -105,7 +133,7 @@ class TestParseThinkingContent:
             "- Dr. Alex: Analytical\n"
             "- Jamie: Enthusiastic\n"
             "\n"
-            'This will ensure at least 3 turns and cover all points.'
+            "This will ensure at least 3 turns and cover all points."
             '{"transcript": [{"speaker": "Alice", "dialogue": "Hello"}]}'
         )
         thinking, cleaned = parse_thinking_content(content)
@@ -190,7 +218,7 @@ class TestParseThinkingContent:
             "\n"
             "This will ensure at least 3 turns and cover all points."
             '{"transcript": [\n'
-            '    {\n'
+            "    {\n"
             '        "speaker": "Dr. Alex Chen",\n'
             '        "dialogue": "Welcome to the podcast, everyone."\n'
             "    },\n"
@@ -206,21 +234,37 @@ class TestParseThinkingContent:
         assert "SurrealDB 3.0" in thinking
         # Verify the JSON is parseable
         import json
+
         parsed = json.loads(cleaned)
         assert len(parsed["transcript"]) == 2
 
 
 class TestValidatedTranscriptParser:
+    def test_schema_requires_configured_speakers(self):
+        schema = create_validated_transcript_schema(["Dr. Alex Chen"])
+
+        assert schema.model_validate({
+            "transcript": [{"speaker": "Dr. Alex Chen", "dialogue": "Hello."}]
+        })
+
+        import pytest
+
+        with pytest.raises(Exception):
+            schema.model_validate({
+                "transcript": [{"speaker": "Alex", "dialogue": "Hello."}]
+            })
+
     def test_canonicalizes_a_complete_replacement_cast(self):
-        parser = create_validated_transcript_parser(
-            ["Dr. Alex Chen", "Jamie Rodriguez"]
-        )
+        parser = create_validated_transcript_parser([
+            "Dr. Alex Chen",
+            "Jamie Rodriguez",
+        ])
 
         transcript = parser.parse(
             '{"transcript": ['
             '{"speaker": "Alex", "dialogue": "Welcome."}, '
             '{"speaker": "Jordan", "dialogue": "Thanks."}'
-            ']}'
+            "]}"
         )
 
         assert [dialogue.speaker for dialogue in transcript.transcript] == [
@@ -229,13 +273,12 @@ class TestValidatedTranscriptParser:
         ]
 
     def test_rejects_an_ambiguous_replacement_speaker(self):
-        parser = create_validated_transcript_parser(
-            ["Dr. Alex Chen", "Jamie Rodriguez"]
-        )
+        parser = create_validated_transcript_parser([
+            "Dr. Alex Chen",
+            "Jamie Rodriguez",
+        ])
 
         import pytest
 
         with pytest.raises(Exception, match="Invalid speaker names: Sam"):
-            parser.parse(
-                '{"transcript": [{"speaker": "Sam", "dialogue": "Hello."}]}'
-            )
+            parser.parse('{"transcript": [{"speaker": "Sam", "dialogue": "Hello."}]}')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,8 @@
 Tests for core utility functions
 """
 
+from pathlib import Path
+
 from podcast_creator.core import (
     create_outline_parser,
     create_validated_transcript_schema,
@@ -10,7 +12,24 @@ from podcast_creator.core import (
     create_validated_transcript_parser,
     extract_text_content,
     parse_thinking_content,
+    trim_trailing_silence,
 )
+
+
+class TestTrailingSilenceTrim:
+    def test_replaces_a_clip_with_its_trimmed_version(self, tmp_path, monkeypatch):
+        clip = tmp_path / "clip.mp3"
+        clip.write_bytes(b"padded")
+
+        def fake_run(command, **_):
+            Path(command[-1]).write_bytes(b"trimmed")
+
+        monkeypatch.setattr("podcast_creator.core.subprocess.run", fake_run)
+        monkeypatch.setattr("imageio_ffmpeg.get_ffmpeg_exe", lambda: "ffmpeg")
+
+        trim_trailing_silence(clip)
+
+        assert clip.read_bytes() == b"trimmed"
 
 
 class TestOutlineParser:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,6 +1,7 @@
 """
 Tests for node config merging logic
 """
+
 import asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
 from pathlib import Path
@@ -12,15 +13,38 @@ from podcast_creator.nodes import (
 )
 
 
-def _setup_language_mocks(mock_factory, mock_prompter, mock_parser):
+def _setup_language_mocks(mock_factory, mock_prompter):
     """Helper to wire up common mocks for LLM node tests."""
     mock_lc = MagicMock()
-    mock_lc.ainvoke = AsyncMock(return_value=MagicMock(content='{"segments": []}'))
+    mock_lc.ainvoke = AsyncMock(
+        return_value=MagicMock(
+            content="""{"segments": [
+        {"name": "One", "description": "First", "size": "short"},
+        {"name": "Two", "description": "Second", "size": "medium"},
+        {"name": "Three", "description": "Third", "size": "long"}
+    ]}"""
+        )
+    )
     mock_model = MagicMock()
     mock_model.to_langchain.return_value = mock_lc
     mock_factory.create_language.return_value = mock_model
     mock_prompter.return_value.render.return_value = "prompt"
-    mock_parser.invoke.return_value = MagicMock(segments=[])
+
+
+def _assert_schema_config(mock_factory, max_tokens, **extra):
+    config = mock_factory.create_language.call_args.kwargs["config"]
+    assert config["max_tokens"] == max_tokens
+    assert config["structured"]["type"] == "json_schema"
+    assert config["structured"]["strict"] is True
+    assert config["structured"]["name"] == "podcast_outline"
+    assert (
+        config["structured"]["schema"].model_json_schema()["properties"]["segments"][
+            "minItems"
+        ]
+        == 3
+    )
+    for key, value in extra.items():
+        assert config[key] == value
 
 
 class TestOutlineConfigMerging:
@@ -28,12 +52,9 @@ class TestOutlineConfigMerging:
 
     @patch("podcast_creator.nodes.AIFactory")
     @patch("podcast_creator.nodes.get_outline_prompter")
-    @patch("podcast_creator.nodes.outline_parser")
-    def test_empty_config_preserves_defaults(
-        self, mock_parser, mock_prompter, mock_factory
-    ):
+    def test_empty_config_preserves_defaults(self, mock_prompter, mock_factory):
         """Test that empty outline_config preserves default max_tokens and structured"""
-        _setup_language_mocks(mock_factory, mock_prompter, mock_parser)
+        _setup_language_mocks(mock_factory, mock_prompter)
 
         state = {
             "briefing": "test",
@@ -45,20 +66,13 @@ class TestOutlineConfigMerging:
 
         asyncio.run(generate_outline_node(state, config))
 
-        mock_factory.create_language.assert_called_once_with(
-            "openai",
-            "gpt-4o-mini",
-            config={"max_tokens": 3000, "structured": {"type": "json"}},
-        )
+        _assert_schema_config(mock_factory, 3000)
 
     @patch("podcast_creator.nodes.AIFactory")
     @patch("podcast_creator.nodes.get_outline_prompter")
-    @patch("podcast_creator.nodes.outline_parser")
-    def test_user_config_overrides_defaults(
-        self, mock_parser, mock_prompter, mock_factory
-    ):
+    def test_user_config_overrides_defaults(self, mock_prompter, mock_factory):
         """Test that user config overrides default max_tokens"""
-        _setup_language_mocks(mock_factory, mock_prompter, mock_parser)
+        _setup_language_mocks(mock_factory, mock_prompter)
 
         state = {
             "briefing": "test",
@@ -70,20 +84,13 @@ class TestOutlineConfigMerging:
 
         asyncio.run(generate_outline_node(state, config))
 
-        mock_factory.create_language.assert_called_once_with(
-            "openai",
-            "gpt-4o-mini",
-            config={"max_tokens": 6000, "structured": {"type": "json"}},
-        )
+        _assert_schema_config(mock_factory, 6000)
 
     @patch("podcast_creator.nodes.AIFactory")
     @patch("podcast_creator.nodes.get_outline_prompter")
-    @patch("podcast_creator.nodes.outline_parser")
-    def test_user_config_adds_new_keys(
-        self, mock_parser, mock_prompter, mock_factory
-    ):
+    def test_user_config_adds_new_keys(self, mock_prompter, mock_factory):
         """Test that user config can add new keys like temperature"""
-        _setup_language_mocks(mock_factory, mock_prompter, mock_parser)
+        _setup_language_mocks(mock_factory, mock_prompter)
 
         state = {
             "briefing": "test",
@@ -95,24 +102,13 @@ class TestOutlineConfigMerging:
 
         asyncio.run(generate_outline_node(state, config))
 
-        mock_factory.create_language.assert_called_once_with(
-            "openai",
-            "gpt-4o-mini",
-            config={
-                "max_tokens": 3000,
-                "structured": {"type": "json"},
-                "temperature": 0.7,
-            },
-        )
+        _assert_schema_config(mock_factory, 3000, temperature=0.7)
 
     @patch("podcast_creator.nodes.AIFactory")
     @patch("podcast_creator.nodes.get_outline_prompter")
-    @patch("podcast_creator.nodes.outline_parser")
-    def test_none_config_preserves_defaults(
-        self, mock_parser, mock_prompter, mock_factory
-    ):
+    def test_none_config_preserves_defaults(self, mock_prompter, mock_factory):
         """Test that None outline_config preserves defaults"""
-        _setup_language_mocks(mock_factory, mock_prompter, mock_parser)
+        _setup_language_mocks(mock_factory, mock_prompter)
 
         state = {
             "briefing": "test",
@@ -124,11 +120,7 @@ class TestOutlineConfigMerging:
 
         asyncio.run(generate_outline_node(state, config))
 
-        mock_factory.create_language.assert_called_once_with(
-            "openai",
-            "gpt-4o-mini",
-            config={"max_tokens": 3000, "structured": {"type": "json"}},
-        )
+        _assert_schema_config(mock_factory, 3000)
 
 
 class TestTranscriptConfigMerging:
@@ -173,15 +165,12 @@ class TestTranscriptConfigMerging:
 
         asyncio.run(generate_transcript_node(state, config))
 
-        mock_factory.create_language.assert_called_once_with(
-            "openai",
-            "gpt-4o-mini",
-            config={
-                "max_tokens": 10000,
-                "structured": {"type": "json"},
-                "temperature": 0.8,
-            },
-        )
+        config = mock_factory.create_language.call_args.kwargs["config"]
+        assert config["max_tokens"] == 10000
+        assert config["temperature"] == 0.8
+        assert config["structured"]["type"] == "json_schema"
+        assert config["structured"]["strict"] is True
+        assert config["structured"]["name"] == "podcast_transcript"
 
 
 class TestLanguagePassthrough:
@@ -189,12 +178,9 @@ class TestLanguagePassthrough:
 
     @patch("podcast_creator.nodes.AIFactory")
     @patch("podcast_creator.nodes.get_outline_prompter")
-    @patch("podcast_creator.nodes.outline_parser")
-    def test_outline_passes_language_to_template(
-        self, mock_parser, mock_prompter, mock_factory
-    ):
+    def test_outline_passes_language_to_template(self, mock_prompter, mock_factory):
         """Test that language is passed to outline template render"""
-        _setup_language_mocks(mock_factory, mock_prompter, mock_parser)
+        _setup_language_mocks(mock_factory, mock_prompter)
 
         state = {
             "briefing": "test",
@@ -212,12 +198,9 @@ class TestLanguagePassthrough:
 
     @patch("podcast_creator.nodes.AIFactory")
     @patch("podcast_creator.nodes.get_outline_prompter")
-    @patch("podcast_creator.nodes.outline_parser")
-    def test_outline_passes_none_when_no_language(
-        self, mock_parser, mock_prompter, mock_factory
-    ):
+    def test_outline_passes_none_when_no_language(self, mock_prompter, mock_factory):
         """Test that language is None when not set in state"""
-        _setup_language_mocks(mock_factory, mock_prompter, mock_parser)
+        _setup_language_mocks(mock_factory, mock_prompter)
 
         state = {
             "briefing": "test",
@@ -566,7 +549,9 @@ class TestPerSpeakerTtsOverride:
 
     @patch("podcast_creator.nodes.generate_single_audio_clip", new_callable=AsyncMock)
     @patch("podcast_creator.nodes.asyncio.sleep", new_callable=AsyncMock)
-    def test_speaker_tts_config_override_replaces_profile(self, mock_sleep, mock_gen_clip):
+    def test_speaker_tts_config_override_replaces_profile(
+        self, mock_sleep, mock_gen_clip
+    ):
         """Speaker with tts_config replaces profile config entirely (no merge)"""
         mock_gen_clip.return_value = Path("/tmp/clip.mp3")
 
@@ -604,7 +589,9 @@ class TestPerSpeakerTtsOverride:
 
     @patch("podcast_creator.nodes.generate_single_audio_clip", new_callable=AsyncMock)
     @patch("podcast_creator.nodes.asyncio.sleep", new_callable=AsyncMock)
-    def test_speaker_empty_tts_config_does_not_fallthrough(self, mock_sleep, mock_gen_clip):
+    def test_speaker_empty_tts_config_does_not_fallthrough(
+        self, mock_sleep, mock_gen_clip
+    ):
         """Speaker with tts_config={} does NOT fall through to profile config"""
         mock_gen_clip.return_value = Path("/tmp/clip.mp3")
 
@@ -728,9 +715,7 @@ class TestTtsRetry:
     def test_no_retry_on_value_error(self, mock_sleep, mock_factory):
         """generate_all_audio_node does not retry ValueError from TTS"""
         mock_tts = MagicMock()
-        mock_tts.agenerate_speech = AsyncMock(
-            side_effect=ValueError("invalid voice")
-        )
+        mock_tts.agenerate_speech = AsyncMock(side_effect=ValueError("invalid voice"))
         mock_factory.create_text_to_speech.return_value = mock_tts
 
         state = self._make_state(["Alice"])
@@ -752,9 +737,7 @@ class TestTtsRetry:
         """Retry config from configurable dict is respected for TTS"""
         mock_tts = MagicMock()
         # Always fails — with max_attempts=2 we expect exactly 2 calls
-        mock_tts.agenerate_speech = AsyncMock(
-            side_effect=RuntimeError("always fails")
-        )
+        mock_tts.agenerate_speech = AsyncMock(side_effect=RuntimeError("always fails"))
         mock_factory.create_text_to_speech.return_value = mock_tts
 
         state = self._make_state(["Alice"])
@@ -773,4 +756,5 @@ class TestTtsRetry:
 
 if __name__ == "__main__":
     import pytest
+
     pytest.main([__file__, "-v"])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -351,6 +351,33 @@ class TestTtsConfigPassthrough:
         )
 
     @patch("podcast_creator.nodes.AIFactory")
+    def test_tts_max_tokens_is_sent_with_the_audio_request(self, mock_factory):
+        mock_tts = MagicMock()
+        mock_tts.agenerate_speech = AsyncMock()
+        mock_factory.create_text_to_speech.return_value = mock_tts
+
+        dialogue = MagicMock(speaker="Alice", dialogue="Hello world")
+        dialogue_info = {
+            "dialogue": dialogue,
+            "index": 0,
+            "output_dir": Path("/tmp/test_output"),
+            "tts_provider": "openai_compatible",
+            "tts_model": "qwen",
+            "voices": {"Alice": "Ryan"},
+            "tts_config": {"max_tokens": 1050},
+        }
+
+        with patch("pathlib.Path.mkdir"):
+            asyncio.run(generate_single_audio_clip(dialogue_info))
+
+        mock_tts.agenerate_speech.assert_awaited_once_with(
+            text="Hello world",
+            voice="Ryan",
+            output_file=Path("/tmp/test_output/clips/0000.mp3"),
+            max_tokens=1050,
+        )
+
+    @patch("podcast_creator.nodes.AIFactory")
     def test_tts_config_empty_passes_none_for_named_params(self, mock_factory):
         """Test that empty tts_config passes None for api_key and base_url"""
         mock_tts = MagicMock()


### PR DESCRIPTION
## Summary

Recover a complete, consistent replacement cast emitted by a transcript model and canonicalize it to the configured speakers.

## Root cause

The parser rejected every non-exact display name before the transcript could be rendered. Models can consistently emit a replacement pair such as `Alex` / `Jordan` even when the prompt supplies `Dr. Alex Chen` / `Jamie Rodriguez`, turning an otherwise valid episode into a hard failure.

## Behaviour

- Exact configured names remain unchanged.
- Unambiguous name tokens resolve to the configured speaker.
- A complete replacement cast maps deterministically to the configured speaker order.
- An incomplete ambiguous replacement remains a validation error.

## Validation

- `pytest tests/test_core.py -q` (22 passed)
- `ruff check src/podcast_creator/core.py tests/test_core.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/lfnovo/podcast-creator/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

